### PR TITLE
Moved populateVoiceList to window.onload

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,8 +14,8 @@ let voices = [];
  * Automatically run this function to initialize speechSynthesis functionality.
  */
 (function init() {
-	// populate the voice select element with speechSynthesisVoices
-	populateVoiceList();
+	// populate the voice select element with speechSynthesisVoices once the window has loaded
+	window.onload = populateVoiceList;
 	
 	// if there isn't a onvoiceschanged function bound, bind it to populateVoiceList
 	if (SPEECH_SYNTHESIS.onvoiceschanged !== undefined) 


### PR DESCRIPTION
I believe there was a bug introduced in PR #3. Js was cached on the browser and page continued to work but on new browsers it did not. The populateVoiceList was trying to find the select html element before the page loaded. I moved it to window.onload which runs the method once the page has loaded. 