### PR TITLE
Initial Editable Tiles Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 virtualenv
 .idea
-index.html
 __pycache__
 .DS_Store
- dist
+dist
 node_modules
 
  # local env files
@@ -23,3 +22,4 @@ node_modules
  *.njsproj
  *.sln
  *.sw?
+.vscode

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Many people requested to donate to the project. I'd first recommend you donate t
 * [npm LTS](https://nodejs.org/en/)
 
 #### Dev Setup
-All commands are ran inside of a terminal inside of the freespeechvue folder
+All commands are ran inside of a terminal inside of the vueapp folder
 ```
 npm install
 ```
@@ -24,14 +24,14 @@ npm install
 npm run serve
 ```
 
-### Compiles and minifies for production. Production ready code in /frespeech
+### Compiles and minifies for production. Production ready code in /vueapp/dist
 ```
 npm run build
 ```
 
 ### Lints and fixes files
 ```
-npm run li
+npm run lint
 ``` 
 
 ## Contributing
@@ -43,7 +43,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 ## Authors
 
 * **Archer Calder** - *Initial work* - [Merkie](https://github.com/Merkie)
-* **Bailey Townsend** - *Help with text to speech functionality* - [Fatfingers23](https://github.com/fatfingers23)
+* **Bailey Townsend** - *Core Team Member/Developer* - [GitHub](https://github.com/fatfingers23) [Linkedin](https://www.linkedin.com/in/bailey-townsend-25b195105)
 * **Rees Draminski** - *Help with JavaScript* - [reesdraminski](https://github.com/reesdraminski)
 
 ## License

--- a/build.json
+++ b/build.json
@@ -1,183 +1,523 @@
 {
-  "home":{
-    "row1": [
-      { "name": "No", "text": "No", "accent":"peach", "image":"https://img.icons8.com/officexs/64/000000/cancel-2.png"},
-      { "name": "Little", "text": "Little", "image":"https://img.icons8.com/officexs/64/000000/cursor.png"},
-      { "name": "Off", "text": "Off", "image":"https://img.icons8.com/officexs/64/000000/disclaimer.png"},
-      { "name": "Good", "text": "Good", "image":"https://img.icons8.com/officexs64/000000/good-quality.png"},
-      { "name": "Some", "text": "Some", "image":"https://img.icons8.com/officexs/64/000000/plus-math.png"},
-      { "name": "Finished", "text": "Finished", "image":"https://img.icons8.com/officexs/64/000000/so-so.png"},
-      { "name": "Bad", "text": "Bad", "image":"https://img.icons8.com/officexs/64/000000/remove-tag.png"},
-      { "name": "Out", "text": "Out", "image":"https://img.icons8.com/officexs/64/000000/hand-right.png"},
-      { "name": "Mine", "text": "Mine", "image":"https://img.icons8.com/officexs/64/000000/oppression.png"},
-      { "name": "Down", "text": "Down", "image":"https://img.icons8.com/officexs/64/000000/long-arrow-down.png"},
-      { "name": "Up", "text": "Up", "accent":"mint","image":"https://img.icons8.com/officexs/64/000000/finger-and-thumb.png"},
-      { "name": "Keyboard", "text": " ", "accent":"mint","image":"https://img.icons8.com/officexs/64/000000/keyboard.png", "navigation": "keyboard"}
-    ],
-    "row2":[
-      { "name": "Feel", "text": "Feel", "accent":"peach", "image":"https://img.icons8.com/officexs/64/000000/in-love.png" },
-      { "name": "Work", "text": "Work", "accent":"peach", "image":"https://img.icons8.com/officexs/64/000000/work.png"},
-      { "name": "New", "text": "New", "image":"https://img.icons8.com/officexs/64/000000/new.png"},
-      { "name": "Play", "text": "Play", "image":"https://img.icons8.com/officexs/64/000000/play.png"},
-      { "name": "Have", "text": "Have", "image":"https://img.icons8.com/officexs/64/000000/hospital-2.png"},
-      { "name": "Stop", "text": "Stop", "image":"https://img.icons8.com/officexs/64/000000/stop-sign.png"},
-      { "name": "Read", "text": "Read", "image":"https://img.icons8.com/officexs/64/000000/book.png" },
-      { "name": "Fast", "text": "Fast", "image":"https://img.icons8.com/officexs/64/000000/double-right.png"},
-      { "name": "You", "text": "You", "image":"https://img.icons8.com/officexs/64/000000/youtube.png"},
-      { "name": "Like", "text": "Like", "image":"https://img.icons8.com/officexs/64/000000/filled-like.png"},
-      { "name": "More", "text": "More", "image":"https://img.icons8.com/officexs/64/000000/more.png"},
-      { "name": "They", "text": "They", "accent":"mint", "image":"https://img.icons8.com/officexs/64/000000/street-view.png"}
-    ],
-    "row3":[
-      { "name": "Time", "text": "Time", "accent":"peach", "image":"https://img.icons8.com/officexs/64/000000/time.png"},
-      { "name": "Big", "text": "Big", "accent":"peach", "image":"https://img.icons8.com/officexs/64/000000/big-ben.png"},
-      { "name": "Go", "text": "Go", "image":"https://img.icons8.com/officexs/64/000000/go.png"},
-      { "name": "Want", "text": "Want", "image":"https://img.icons8.com/officexs/64/000000/gift.png"},
-      { "name": "Help", "text": "Help", "image":"https://img.icons8.com/officexs/64/000000/volunteering.png"},
-      { "name": "It", "text": "It", "image":"https://img.icons8.com/officexs/64/000000/dog.png"},
-      { "name": "Do", "text": "Do", "image":"https://img.icons8.com/officexs/64/000000/to-do.png"},
-      { "name": "Come", "text": "Come", "image":"https://img.icons8.com/officexs/64/000000/comet.png"},
-      { "name": "All", "text": "All", "image":"https://img.icons8.com/officexs/64/000000/alligator.png"},
-      { "name": "He", "text": "He", "image":"https://img.icons8.com/officexs/64/000000/standing-man.png"},
-      { "name": "Get", "text": "Get", "image":"https://img.icons8.com/officexs/64/000000/quote-right.png"},
-      { "name": "Color", "text": "Color", "accent":"mint", "image":"https://img.icons8.com/officexs/64/000000/rgb-circle-1.png"}
-    ],
-    "row4":[
-      { "name": "My", "text": "My", "accent":"peach", "image":"https://img.icons8.com/officexs/64/000000/oppression.png"},
-      { "name": "Me", "text": "Me", "accent":"peach", "image":"https://img.icons8.com/officexs/64/000000/person-male.png"},
-      { "name": "And", "text": "And", "image":"https://img.icons8.com/officexs/64/000000/bicycle.png"},
-      { "name": "Wear", "text": "Wear", "image":"https://img.icons8.com/officexs/64/000000/shirt.png"},
-      { "name": "That", "text": "That", "image":"https://img.icons8.com/officexs/64/000000/map-marker.png"},
-      { "name": "Am", "text": "Am", "image":"https://img.icons8.com/officexs/64/000000/map-pin.png"},
-      { "name": "Please", "text": "Please", "image":"https://img.icons8.com/officexs/64/000000/synchronize.png"},
-      { "name": "What", "text": "What", "image":"https://img.icons8.com/officexs/64/000000/talk-male.png"},
-      { "name": "+s", "text": "Needs to be added", "image":"https://img.icons8.com/officexs/64/000000/numbered-list.png"},
-      { "name": "There", "text": "There", "image":"https://img.icons8.com/officexs/64/000000/city-square.png"},
-      { "name": "In", "text": "In", "image":"https://img.icons8.com/officexs/64/000000/walking.png"},
-      { "name": "A", "text": "Uh", "accent":"mint", "image":"https://img.icons8.com/officexs/64/000000/xbox-a.png"}
-    ],
-    "row5":[
-      { "name": "Were", "text": "Were", "accent":"peach", "image":"https://img.icons8.com/officexs/64/000000/jog-reverse.png"},
-      { "name": "On", "text": "On", "accent":"peach",  "image":"https://img.icons8.com/officexs/64/000000/ceiling-fan-on.png"},
-      { "name": "Was", "text": "Was", "image":"https://img.icons8.com/officexs/64/000000/wasp.png"},
-      { "name": "I", "text": "Eye", "image":"https://img.icons8.com/officexs/64/000000/visible.png"},
-      { "name": "End", "text": "End", "accent":"violet", "image":"https://img.icons8.com/officexs/64/000000/end-call.png"},
-      { "name": "Is", "text": "Is", "accent":"violet", "image":"https://img.icons8.com/officexs/64/000000/year-of-snake.png"},
-      { "name": "To", "text": "To", "accent":"violet", "image":"https://img.icons8.com/officexs/64/000000/students.png"},
-      { "name": "We", "text": "We", "accent":"violet", "image":"https://img.icons8.com/officexs/64/000000/conference-call.png"},
-      { "name": "Numbers", "text": " ", "accent":"violet", "image":"https://img.icons8.com/officexs/64/000000/superscript.png"},
-      { "name": "Are", "text": "Are", "accent":"violet", "image":"https://img.icons8.com/officexs/64/000000/fantasy.png"},
-      { "name": "The", "text": "The", "accent":"violet", "image":"https://img.icons8.com/officexs/64/000000/the-flash-sign.png"},
-      { "name": "An", "text": "An", "accent":"violet", "image":"https://img.icons8.com/officexs/64/000000/north.png"}
-    ]
-  },
-  "keyboard":{
-    "row1": [
-      
-        { "name": "A",
-          "text": "A"
+  "home": {
+    "tileData": [
+        {
+          "name": "No",
+          "text": "No",
+          "accent": "peach",
+          "image": "https://img.icons8.com/officexs/64/000000/cancel-2.png",
+          "id": 0
         },
         {
-          "name": "B",
-          "text": "B"
+          "name": "Little",
+          "text": "Little",
+          "image": "https://img.icons8.com/officexs/64/000000/cursor.png",
+          "id": 1
         },
         {
-          "name": "C",
-          "text": "C"
+          "name": "Off",
+          "text": "Off",
+          "image": "https://img.icons8.com/officexs/64/000000/disclaimer.png",
+          "id": 2
         },
         {
-          "name": "D",
-          "text": "D"
+          "name": "Good",
+          "text": "Good",
+          "image": "https://img.icons8.com/officexs64/000000/good-quality.png",
+          "id": 3
         },
         {
-          "name": "E",
-          "text": "E"
+          "name": "Some",
+          "text": "Some",
+          "image": "https://img.icons8.com/officexs/64/000000/plus-math.png",
+          "id": 4
         },
         {
-          "name": "F",
-          "text": "F"
+          "name": "Finished",
+          "text": "Finished",
+          "image": "https://img.icons8.com/officexs/64/000000/so-so.png",
+          "id": 5
         },
         {
-          "name": "G",
-          "text": "G"
+          "name": "Bad",
+          "text": "Bad",
+          "image": "https://img.icons8.com/officexs/64/000000/remove-tag.png",
+          "id": 6
         },
         {
-          "name": "H",
-          "text": "H"
+          "name": "Out",
+          "text": "Out",
+          "image": "https://img.icons8.com/officexs/64/000000/hand-right.png",
+          "id": 7
+        },
+        {
+          "name": "Mine",
+          "text": "Mine",
+          "image": "https://img.icons8.com/officexs/64/000000/oppression.png",
+          "id": 8
+        },
+        {
+          "name": "Down",
+          "text": "Down",
+          "image": "https://img.icons8.com/officexs/64/000000/long-arrow-down.png",
+          "id": 9
+        },
+        {
+          "name": "Up",
+          "text": "Up",
+          "accent": "mint",
+          "image": "https://img.icons8.com/officexs/64/000000/finger-and-thumb.png",
+          "id": 10
+        },
+        {
+          "name": "Keyboard",
+          "text": " ",
+          "accent": "mint",
+          "image": "https://img.icons8.com/officexs/64/000000/keyboard.png",
+          "navigation": "keyboard",
+          "id": 11
+        },
+        {
+          "name": "Feel",
+          "text": "Feel",
+          "accent": "peach",
+          "image": "https://img.icons8.com/officexs/64/000000/in-love.png",
+          "id": 12
+        },
+        {
+          "name": "Work",
+          "text": "Work",
+          "accent": "peach",
+          "image": "https://img.icons8.com/officexs/64/000000/work.png",
+          "id": 13
+        },
+        {
+          "name": "New",
+          "text": "New",
+          "image": "https://img.icons8.com/officexs/64/000000/new.png",
+          "id": 14
+        },
+        {
+          "name": "Play",
+          "text": "Play",
+          "image": "https://img.icons8.com/officexs/64/000000/play.png",
+          "id": 15
+        },
+        {
+          "name": "Have",
+          "text": "Have",
+          "image": "https://img.icons8.com/officexs/64/000000/hospital-2.png",
+          "id": 16
+        },
+        {
+          "name": "Stop",
+          "text": "Stop",
+          "image": "https://img.icons8.com/officexs/64/000000/stop-sign.png",
+          "id": 17
+        },
+        {
+          "name": "Read",
+          "text": "Read",
+          "image": "https://img.icons8.com/officexs/64/000000/book.png",
+          "id": 18
+        },
+        {
+          "name": "Fast",
+          "text": "Fast",
+          "image": "https://img.icons8.com/officexs/64/000000/double-right.png",
+          "id": 19
+        },
+        {
+          "name": "You",
+          "text": "You",
+          "image": "https://img.icons8.com/officexs/64/000000/youtube.png",
+          "id": 20
+        },
+        {
+          "name": "Like",
+          "text": "Like",
+          "image": "https://img.icons8.com/officexs/64/000000/filled-like.png",
+          "id": 21
+        },
+        {
+          "name": "More",
+          "text": "More",
+          "image": "https://img.icons8.com/officexs/64/000000/more.png",
+          "id": 22
+        },
+        {
+          "name": "They",
+          "text": "They",
+          "accent": "mint",
+          "image": "https://img.icons8.com/officexs/64/000000/street-view.png",
+          "id": 23
+        },
+        {
+          "name": "Time",
+          "text": "Time",
+          "accent": "peach",
+          "image": "https://img.icons8.com/officexs/64/000000/time.png",
+          "id": 24
+        },
+        {
+          "name": "Big",
+          "text": "Big",
+          "accent": "peach",
+          "image": "https://img.icons8.com/officexs/64/000000/big-ben.png",
+          "id": 25
+        },
+        {
+          "name": "Go",
+          "text": "Go",
+          "image": "https://img.icons8.com/officexs/64/000000/go.png",
+          "id": 26
+        },
+        {
+          "name": "Want",
+          "text": "Want",
+          "image": "https://img.icons8.com/officexs/64/000000/gift.png",
+          "id": 27
+        },
+        {
+          "name": "Help",
+          "text": "Help",
+          "image": "https://img.icons8.com/officexs/64/000000/volunteering.png",
+          "id": 28
+        },
+        {
+          "name": "It",
+          "text": "It",
+          "image": "https://img.icons8.com/officexs/64/000000/dog.png",
+          "id": 29
+        },
+        {
+          "name": "Do",
+          "text": "Do",
+          "image": "https://img.icons8.com/officexs/64/000000/to-do.png",
+          "id": 30
+        },
+        {
+          "name": "Come",
+          "text": "Come",
+          "image": "https://img.icons8.com/officexs/64/000000/comet.png",
+          "id": 31
+        },
+        {
+          "name": "All",
+          "text": "All",
+          "image": "https://img.icons8.com/officexs/64/000000/alligator.png",
+          "id": 32
+        },
+        {
+          "name": "He",
+          "text": "He",
+          "image": "https://img.icons8.com/officexs/64/000000/standing-man.png",
+          "id": 33
+        },
+        {
+          "name": "Get",
+          "text": "Get",
+          "image": "https://img.icons8.com/officexs/64/000000/quote-right.png",
+          "id": 34
+        },
+        {
+          "name": "Color",
+          "text": "Color",
+          "accent": "mint",
+          "image": "https://img.icons8.com/officexs/64/000000/rgb-circle-1.png",
+          "id": 35
+        },
+        {
+          "name": "My",
+          "text": "My",
+          "accent": "peach",
+          "image": "https://img.icons8.com/officexs/64/000000/oppression.png",
+          "id": 36
+        },
+        {
+          "name": "Me",
+          "text": "Me",
+          "accent": "peach",
+          "image": "https://img.icons8.com/officexs/64/000000/person-male.png",
+          "id": 37
+        },
+        {
+          "name": "And",
+          "text": "And",
+          "image": "https://img.icons8.com/officexs/64/000000/bicycle.png",
+          "id": 38
+        },
+        {
+          "name": "Wear",
+          "text": "Wear",
+          "image": "https://img.icons8.com/officexs/64/000000/shirt.png",
+          "id": 39
+        },
+        {
+          "name": "That",
+          "text": "That",
+          "image": "https://img.icons8.com/officexs/64/000000/map-marker.png",
+          "id": 40
+        },
+        {
+          "name": "Am",
+          "text": "Am",
+          "image": "https://img.icons8.com/officexs/64/000000/map-pin.png",
+          "id": 41
+        },
+        {
+          "name": "Please",
+          "text": "Please",
+          "image": "https://img.icons8.com/officexs/64/000000/synchronize.png",
+          "id": 42
+        },
+        {
+          "name": "What",
+          "text": "What",
+          "image": "https://img.icons8.com/officexs/64/000000/talk-male.png",
+          "id": 43
+        },
+        {
+          "name": "+s",
+          "text": "Needs to be added",
+          "image": "https://img.icons8.com/officexs/64/000000/numbered-list.png",
+          "id": 44
+        },
+        {
+          "name": "There",
+          "text": "There",
+          "image": "https://img.icons8.com/officexs/64/000000/city-square.png",
+          "id": 45
+        },
+        {
+          "name": "In",
+          "text": "In",
+          "image": "https://img.icons8.com/officexs/64/000000/walking.png",
+          "id": 46
+        },
+        {
+          "name": "A",
+          "text": "Uh",
+          "accent": "mint",
+          "image": "https://img.icons8.com/officexs/64/000000/xbox-a.png",
+          "id": 47
+        },
+        {
+          "name": "Were",
+          "text": "Were",
+          "accent": "peach",
+          "image": "https://img.icons8.com/officexs/64/000000/jog-reverse.png",
+          "id": 48
+        },
+        {
+          "name": "On",
+          "text": "On",
+          "accent": "peach",
+          "image": "https://img.icons8.com/officexs/64/000000/ceiling-fan-on.png",
+          "id": 49
+        },
+        {
+          "name": "Was",
+          "text": "Was",
+          "image": "https://img.icons8.com/officexs/64/000000/wasp.png",
+          "id": 50
         },
         {
           "name": "I",
-          "text": "I"
+          "text": "Eye",
+          "image": "https://img.icons8.com/officexs/64/000000/visible.png",
+          "id": 51
+        },
+        {
+          "name": "End",
+          "text": "End",
+          "accent": "violet",
+          "image": "https://img.icons8.com/officexs/64/000000/end-call.png",
+          "id": 52
+        },
+        {
+          "name": "Is",
+          "text": "Is",
+          "accent": "violet",
+          "image": "https://img.icons8.com/officexs/64/000000/year-of-snake.png",
+          "id": 53
+        },
+        {
+          "name": "To",
+          "text": "To",
+          "accent": "violet",
+          "image": "https://img.icons8.com/officexs/64/000000/students.png",
+          "id": 54
+        },
+        {
+          "name": "We",
+          "text": "We",
+          "accent": "violet",
+          "image": "https://img.icons8.com/officexs/64/000000/conference-call.png",
+          "id": 55
+        },
+        {
+          "name": "Numbers",
+          "text": " ",
+          "accent": "violet",
+          "image": "https://img.icons8.com/officexs/64/000000/superscript.png",
+          "id": 56
+        },
+        {
+          "name": "Are",
+          "text": "Are",
+          "accent": "violet",
+          "image": "https://img.icons8.com/officexs/64/000000/fantasy.png",
+          "id": 57
+        },
+        {
+          "name": "The",
+          "text": "The",
+          "accent": "violet",
+          "image": "https://img.icons8.com/officexs/64/000000/the-flash-sign.png",
+          "id": 58
+        },
+        {
+          "name": "An",
+          "text": "An",
+          "accent": "violet",
+          "image": "https://img.icons8.com/officexs/64/000000/north.png",
+          "id": 59
+        }
+    ]
+  },
+  "keyboard": {
+    "tileData": [      
+        {
+          "name": "A",
+          "text": "A",
+          "id": 0
+        },
+        {
+          "name": "B",
+          "text": "B",
+          "id": 1
+        },
+        {
+          "name": "C",
+          "text": "C",
+          "id": 2
+        },
+        {
+          "name": "D",
+          "text": "D",
+          "id": 3
+        },
+        {
+          "name": "E",
+          "text": "E",
+          "id": 4
+        },
+        {
+          "name": "F",
+          "text": "F",
+          "id": 5
+        },
+        {
+          "name": "G",
+          "text": "G",
+          "id": 6
+        },
+        {
+          "name": "H",
+          "text": "H",
+          "id": 7
+        },
+        {
+          "name": "I",
+          "text": "I",
+          "id": 8
         },
         {
           "name": "J",
-          "text": "J"
+          "text": "J",
+          "id": 9
         },
         {
           "name": "K",
-          "text": "K"
+          "text": "K",
+          "id": 10
         },
         {
           "name": "L",
-          "text": "L"
+          "text": "L",
+          "id": 11
         },
         {
           "name": "M",
-          "text": "M"
+          "text": "M",
+          "id": 12
         },
         {
           "name": "N",
-          "text": "N"
+          "text": "N",
+          "id": 13
         },
         {
           "name": "O",
-          "text": "O"
+          "text": "O",
+          "id": 14
         },
         {
           "name": "P",
-          "text": "P"
+          "text": "P",
+          "id": 15
         },
         {
           "name": "Q",
-          "text": "Q"
+          "text": "Q",
+          "id": 16
         },
         {
           "name": "R",
-          "text": "R"
+          "text": "R",
+          "id": 17
         },
         {
           "name": "S",
-          "text": "S"
+          "text": "S",
+          "id": 18
         },
         {
           "name": "T",
-          "text": "T"
+          "text": "T",
+          "id": 19
         },
         {
           "name": "U",
-          "text": "U"
+          "text": "U",
+          "id": 20
         },
         {
           "name": "V",
-          "text": "V"
+          "text": "V",
+          "id": 21
         },
         {
           "name": "W",
-          "text": "W"
+          "text": "W",
+          "id": 22
         },
         {
           "name": "X",
-          "text": "X"
+          "text": "X",
+          "id": 23
         },
         {
           "name": "Y",
-          "text": "Y"
+          "text": "Y",
+          "id": 24
         },
         {
           "name": "Z",
-          "text": "Z"
+          "text": "Z",
+          "id": 25
         }
-      
-    ]
+      ]    
   }
 }

--- a/vueapp/babel.config.js
+++ b/vueapp/babel.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-    presets: [
-        '@vue/app'
-    ]
+  presets: ['@vue/app']
 };

--- a/vueapp/package.json
+++ b/vueapp/package.json
@@ -45,6 +45,10 @@
     ],
     "parserOptions": {
       "parser": "babel-eslint"
+    },
+    "rules": {
+      "quotes": [2, "single", { "avoidEscape": true }],
+      "semi": [2, "always"]
     }
   },
   "postcss": {

--- a/vueapp/public/index.html
+++ b/vueapp/public/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+  <title>Freespeech</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">
+  <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet"
+    type="text/css">
+</head>
+
+<body>
+  <noscript>
+    <strong>We're sorry but Freespeech doesn't work properly without JavaScript enabled. Please enable it to
+      continue.</strong>
+  </noscript>
+  <div id="app"></div>
+  <!-- built files will be auto injected -->
+</body>
+
+</html>

--- a/vueapp/src/App.vue
+++ b/vueapp/src/App.vue
@@ -10,7 +10,7 @@
       </div>
 
       <v-spacer />
-      
+
       <v-btn
         icon
         to="/"
@@ -18,7 +18,21 @@
         <v-icon>
           home
         </v-icon>
-      </v-btn>      
+      </v-btn>
+      <v-btn
+        icon
+        v-if="customTilePad && !editMode"
+        @click="this.toggleEditMode"
+      >
+        <v-icon>edit</v-icon>
+      </v-btn>
+      <v-btn
+        icon
+        v-if="customTilePad && editMode"
+        @click="this.toggleEditMode"
+      >
+        <v-icon>save</v-icon>
+      </v-btn>
       <v-btn
         icon
         to="/about"
@@ -26,7 +40,7 @@
         <v-icon>
           info
         </v-icon>
-      </v-btn>      
+      </v-btn>
 
       <v-btn
         icon
@@ -41,24 +55,36 @@
     <v-content>
       <router-view />
       <Settings />
+      <editDialog />
     </v-content>
   </v-app>
 </template>
 
 <script>
-import Settings from "@/views/Settings"
-import {mapActions} from 'vuex'
+import Settings from '@/views/Settings';
+import EditDialog from '@/components/TilePad/EditTileDialog';
+import { mapActions, mapGetters } from 'vuex';
 
 export default {
-    name: 'App',
-    components:{
-      Settings
-    },
-    data: () => ({
+  name: 'App',
+  components: {
+    Settings,
+    EditDialog
+  },
+  data: () => ({
     //
-    }),
+  }),
     methods: {
-      ...mapActions(['toggleSettingsDialogVisibility'])
-    },
+    ...mapActions({        
+      toggleSettingsDialogVisibility: 'settings/toggleSettingsDialogVisibility',
+      toggleEditMode: 'tilePad/toggleEditMode'
+    })
+  },
+  computed: {
+    ...mapGetters({ 
+      customTilePad: 'settings/customTilePad',
+      editMode: 'tilePad/editMode'
+    })
+  },
 };
 </script>

--- a/vueapp/src/components/TilePad/EditTileDialog.vue
+++ b/vueapp/src/components/TilePad/EditTileDialog.vue
@@ -1,0 +1,99 @@
+<template>
+  <v-dialog
+    v-model="editDialogVisibility"
+    persistent
+    max-width="600px"
+  >
+    <v-card>
+      <v-card-title>
+        <span class="headline"> <v-icon>edit</v-icon>Edit</span>
+      </v-card-title>
+      <v-card-text>
+        <v-container>
+          <v-row>
+            <v-col cols="12">
+              <v-form>
+                <v-text-field
+                  :value="currentTileBeingEdited.name"
+                  @input="update('name', $event)"
+                  label="Name"
+                />
+                <v-text-field
+                  :value="currentTileBeingEdited.image"
+                  @input="update('image', $event)"
+                  label="Image URL"
+                />
+                <v-img
+                  max-height="32"
+                  max-width="32"
+                  aspect-ratio="1"
+                  :src="currentTileBeingEdited.image"
+                />
+                <v-text-field 
+                  class="pt-5"
+                  :value="currentTileBeingEdited.text"
+                  @input="update('text', $event)"
+                  label="Text to speak"
+                />
+              </v-form>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          color="blue darken-1"
+          text
+          @click="saveCurrentEdit"          
+        >
+          Save
+        </v-btn>
+
+        <v-btn
+          color="blue darken-1"
+          text
+          @click="toggleEditDialogVisibility"
+        >
+          Close
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import {mapActions, mapGetters} from 'vuex';
+
+export default {
+  name:'EditTileDialog',
+  computed: {
+    ...mapGetters({
+      editDialogVisibility: 'tilePad/editDialogVisibility',
+      currentTileBeingEdited: 'tilePad/currentTileBeingEdited'      
+    }),
+  },
+  methods: {
+    ...mapActions({
+      toggleEditDialogVisibility: 'tilePad/toggleEditDialogVisibility',
+      saveTileEdit: 'tilePad/saveTileEdit',
+      saveEditsToTileBeingEdited: 'tilePad/saveEditsToTileBeingEdited'
+    }),
+    saveCurrentEdit(){
+      this.saveTileEdit();
+      this.toggleEditDialogVisibility();
+    },
+    update(key, value){      
+      this.saveEditsToTileBeingEdited({'key': key, 'value': value});
+    }
+    
+  },
+    //this.editedTileValues = Object.assign({}, this.currentTileBeingEdited);
+
+
+};
+</script>
+
+<style>
+
+</style>

--- a/vueapp/src/components/TilePad/Tile.vue
+++ b/vueapp/src/components/TilePad/Tile.vue
@@ -23,11 +23,11 @@
       </v-row>
       <v-row>
         <v-card-text
-          class=""
+          class
           align="center"
           justify="center"
         >
-          <h3> {{ tileData.name }} </h3>
+          <h3>{{ tileData.name }}</h3>
         </v-card-text>
       </v-row>
     </v-container>
@@ -35,57 +35,77 @@
 </template>
 
 <script>
+import { mapGetters, mapActions } from 'vuex';
 
 export default {
-  name: "Tile",
+  name: 'Tile',
   props: {
     tileData: {
       type: Object,
       default: Object
+    },
+    tilePage:{
+      type: String,
+      default: ''
     }
-  }, computed: {
-        cardColor: function(){
-            let cardHexColor;
+  },
+  computed: {
+    ...mapGetters({
+      editMode: 'tilePad/editMode'
+    }),
+    cardColor: function() {
+      let cardHexColor;
 
-            switch(this.tileData.accent) {
-                case "red":
-                    cardHexColor = "#FF9AA2";
-                    break;
-                case "blush":
-                    cardHexColor = "#FFB7B2";
-                    break;
-                case "peach":
-                    cardHexColor = "#FFB7B2";
-                    break;
-                case "pear":
-                    cardHexColor = "#E2F0CB";
-                    break;
-                case "mint":
-                    cardHexColor = "#B5EAD7";
-                    break;
-                case "violet":
-                    cardHexColor = "#C7CEEA";
-                    break;
-                default:
-                    cardHexColor = ""
-                    break;
-            }
-            return cardHexColor;
-        }
+      switch (this.tileData.accent) {
+        case 'red':
+          cardHexColor = '#FF9AA2';
+          break;
+        case 'blush':
+          cardHexColor = '#FFB7B2';
+          break;
+        case 'peach':
+          cardHexColor = '#FFB7B2';
+          break;
+        case 'pear':
+          cardHexColor = '#E2F0CB';
+          break;
+        case 'mint':
+          cardHexColor = '#B5EAD7';
+          break;
+        case 'violet':
+          cardHexColor = '#C7CEEA';
+          break;
+        default:
+          cardHexColor = '';
+          break;
+      }
+      return cardHexColor;
+    }
   },
   methods: {
-    tileClickedEvent(){
-      if(typeof this.tileData.navigation === 'undefined' || this.tileData.navigation === '')
-      {
-        this.$emit('speakText', this.tileData.text)
-      }else{
-        this.$router.push({name: 'tilePadWithRoute', params: {layout: this.tileData.navigation }})
+    ...mapActions({
+      toggleEditDialogVisibility: 'tilePad/toggleEditDialogVisibility',
+      setCurrentTileBeingEdited: 'tilePad/setCurrentTileBeingEdited'
+    }),
+    tileClickedEvent() {
+      if (this.editMode) {
+        let tileDataToEdit = this.tileData;
+        tileDataToEdit.page = this.tilePage;
+        this.setCurrentTileBeingEdited(tileDataToEdit);
+        this.toggleEditDialogVisibility();
+      } else {
+          if (typeof this.tileData.navigation === 'undefined' ||this.tileData.navigation === '') {
+              this.$emit('speakText', this.tileData.text);
+          } else {
+              this.$router.push({
+                name: 'tilePadWithRoute',
+                params: { layout: this.tileData.navigation }
+              });
+            }
       }
     }
-  },
+  }
 };
 </script>
 
-<style>
-
-</style>
+<style></style>

--- a/vueapp/src/main.js
+++ b/vueapp/src/main.js
@@ -3,13 +3,13 @@ import App from './App.vue';
 import store from './store/store';
 import router from './router';
 import vuetify from './plugins/vuetify';
-import './registerServiceWorker'
+import './registerServiceWorker';
 
 Vue.config.productionTip = false;
 
 new Vue({
-    store,
-    router,
-    vuetify,
-    render: h => h(App)
+  store,
+  router,
+  vuetify,
+  render: h => h(App)
 }).$mount('#app');

--- a/vueapp/src/plugins/vuetify.js
+++ b/vueapp/src/plugins/vuetify.js
@@ -1,11 +1,11 @@
 import Vue from 'vue';
 import Vuetify from 'vuetify/lib';
-import 'material-design-icons-iconfont/dist/material-design-icons.css' // Ensure you are using css-loader
+import 'material-design-icons-iconfont/dist/material-design-icons.css'; // Ensure you are using css-loader
 
 Vue.use(Vuetify);
 
-export default new Vuetify({  
-    icons: {
-    iconfont: 'md',
-  },
+export default new Vuetify({
+  icons: {
+    iconfont: 'md'
+  }
 });

--- a/vueapp/src/registerServiceWorker.js
+++ b/vueapp/src/registerServiceWorker.js
@@ -1,32 +1,34 @@
 /* eslint-disable no-console */
 
-import { register } from 'register-service-worker'
+import { register } from 'register-service-worker';
 
 if (process.env.NODE_ENV === 'production') {
   register(`${process.env.BASE_URL}service-worker.js`, {
-    ready () {
+    ready() {
       console.log(
         'App is being served from cache by a service worker.\n' +
-        'For more details, visit https://goo.gl/AFskqB'
-      )
+          'For more details, visit https://goo.gl/AFskqB'
+      );
     },
-    registered () {
-      console.log('Service worker has been registered.')
+    registered() {
+      console.log('Service worker has been registered.');
     },
-    cached () {
-      console.log('Content has been cached for offline use.')
+    cached() {
+      console.log('Content has been cached for offline use.');
     },
-    updatefound () {
-      console.log('New content is downloading.')
+    updatefound() {
+      console.log('New content is downloading.');
     },
-    updated () {
-      console.log('New content is available; please refresh.')
+    updated() {
+      console.log('New content is available; please refresh.');
     },
-    offline () {
-      console.log('No internet connection found. App is running in offline mode.')
+    offline() {
+      console.log(
+        'No internet connection found. App is running in offline mode.'
+      );
     },
-    error (error) {
-      console.error('Error during service worker registration:', error)
+    error(error) {
+      console.error('Error during service worker registration:', error);
     }
-  })
+  });
 }

--- a/vueapp/src/router.js
+++ b/vueapp/src/router.js
@@ -1,9 +1,9 @@
-import Vue from 'vue'
-import Router from 'vue-router'
-import TilePad from './views/TilePad.vue'
-import About from './views/About.vue'
+import Vue from 'vue';
+import Router from 'vue-router';
+import TilePad from './views/TilePad.vue';
+import About from './views/About.vue';
 
-Vue.use(Router)
+Vue.use(Router);
 
 export default new Router({
   mode: 'history',
@@ -17,7 +17,7 @@ export default new Router({
     {
       path: '/',
       name: 'tilePad',
-      component: TilePad      
+      component: TilePad
     },
     {
       path: '/about',
@@ -25,4 +25,4 @@ export default new Router({
       component: About
     }
   ]
-})
+});

--- a/vueapp/src/store/modules/settings.js
+++ b/vueapp/src/store/modules/settings.js
@@ -1,0 +1,42 @@
+const state = {
+  selectedVoiceIndex: 0,
+  settingsDialogVisibility: false,
+  customTilePad: true
+};
+
+const mutations = {
+  SET_SELECTED_VOICE_INDEX(state, value) {
+    state.selectedVoiceIndex = value;
+  },
+  TOGGLE_SETTINGS_DIALOG_VISIBILITY(state) {
+    state.settingsDialogVisibility = !state.settingsDialogVisibility;
+  },
+  TOGGLE_CUSTOM_TILE_PAD(state){
+    state.customTilePad = !state.customTilePad;
+  }
+};
+
+const actions = {
+  setSelectedVoiceIndex: ({ commit }, value) => {
+    commit('SET_SELECTED_VOICE_INDEX', value);
+  },
+  toggleSettingsDialogVisibility: ({ commit }) => {
+    commit('TOGGLE_SETTINGS_DIALOG_VISIBILITY');
+  },
+  toggleCustomTilePad: ({commit}) => {
+    commit('TOGGLE_CUSTOM_TILE_PAD');
+  }
+};
+
+const getters = {
+  settingsDialogVisibility: state => state.settingsDialogVisibility,
+  selectedVoiceIndex: state => state.selectedVoiceIndex,
+  customTilePad: state => state.customTilePad
+};
+export default {
+  namespaced: true,
+  state,
+  mutations,
+  actions,
+  getters
+};

--- a/vueapp/src/store/modules/tilePad.js
+++ b/vueapp/src/store/modules/tilePad.js
@@ -1,0 +1,71 @@
+
+const state = {
+  customTilePadData: {},
+  editMode: false,
+  editDialogVisibility: false,
+  currentTileBeingEdited: {}
+};
+
+const mutations = {
+  SET_CUSTOM_TILE_PAD_DATA(state, value) {
+    state.customTilePadData = value;
+  },
+  TOGGLE_EDIT_MODE(state){
+    state.editMode = !state.editMode;
+  },
+  TOGGLE_EDIT_DIALOG_VISIBILITY(state){
+    state.editDialogVisibility = !state.editDialogVisibility;
+  },
+  SET_CURRENT_TILE_BEING_EDITED(state, value){
+    state.currentTileBeingEdited = value;
+  },
+  SAVE_EDITS_TO_TILE_BEING_EDITED(state, value){
+    state.currentTileBeingEdited[value.key] = value.value;
+  },
+  SET_TILE_BEING_EDITED(state){    
+    let indexOfTileInCustomTilePadData = state.customTilePadData[state.currentTileBeingEdited.page].tileData.findIndex(tile => tile.id == state.currentTileBeingEdited.id);
+    state.customTilePadData[state.currentTileBeingEdited.page].tileData.splice(indexOfTileInCustomTilePadData, state.currentTileBeingEdited);
+  },
+  SET_EDIT_MODE(state, value){
+    state.editMode = value;
+  }
+};
+
+const actions = {  
+  setCustomTilePadData: ({commit}, value) => {
+    commit('SET_CUSTOM_TILE_PAD_DATA', value);
+  },
+  toggleEditMode: ({commit}) => {
+    commit('TOGGLE_EDIT_MODE');
+  },
+  toggleEditDialogVisibility: ({commit}) => {   
+    commit('TOGGLE_EDIT_DIALOG_VISIBILITY');
+  },
+  setCurrentTileBeingEdited: ({commit}, value) => {
+    commit('SET_CURRENT_TILE_BEING_EDITED', value);
+  },
+  saveEditsToTileBeingEdited: ({commit}, value) => {
+    commit('SAVE_EDITS_TO_TILE_BEING_EDITED', value);
+  },
+  saveTileEdit: ({commit}) => {
+    commit('SET_TILE_BEING_EDITED');
+  },
+  setEditMode: ({commit}, value) => {
+    commit('SET_EDIT_MODE', value);
+  }
+};
+
+const getters = {
+  customTilePadData: state => state.customTilePadData,
+  editMode: state => state.editMode,
+  editDialogVisibility: state => state.editDialogVisibility,
+  currentTileBeingEdited: state => state.currentTileBeingEdited
+};
+
+export default {
+  namespaced: true,
+  state,
+  mutations,
+  actions,
+  getters
+};

--- a/vueapp/src/store/store.js
+++ b/vueapp/src/store/store.js
@@ -1,38 +1,19 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import VuexPersistence from 'vuex-persist'
+import VuexPersistence from 'vuex-persist';
+import settingsModule from './modules/settings';
+import tilePadModule from './modules/tilePad';
 
 Vue.use(Vuex);
 
 const vuexLocal = new VuexPersistence({
-    storage: window.localStorage
-  })
-  
-export default new Vuex.Store({
-    state: {
-        selectedVoiceIndex: 0,
-        settingsDialogVisibility: false,
+  storage: window.localStorage,
+});
 
-    },
-    mutations: {
-        SET_SELECTED_VOICE_INDEX(state, value){
-            state.selectedVoiceIndex = value;
-        },
-        TOGGLE_SETTINGS_DIALOG_VISIBILITY(state){
-            state.settingsDialogVisibility = !state.settingsDialogVisibility;
-        }
-    },
-    actions: {
-        setselectedVoiceIndex: ({commit}, value) => {
-            commit('SET_SELECTED_VOICE_INDEX', value);
-        },
-        toggleSettingsDialogVisibility: ({commit}) => {
-            commit('TOGGLE_SETTINGS_DIALOG_VISIBILITY');
-        } 
-    },
-    getters:{
-        settingsDialogVisibility: state => state.settingsDialogVisibility,
-        selectedVoiceIndex: state => state.selectedVoiceIndex
-    },
-    plugins: [vuexLocal.plugin]
+export default new Vuex.Store({
+  modules: {
+    settings: settingsModule,
+    tilePad: tilePadModule
+  },
+  plugins: [vuexLocal.plugin]
 });

--- a/vueapp/src/views/About.vue
+++ b/vueapp/src/views/About.vue
@@ -5,20 +5,20 @@
 </template>
 
 <script>
-import readMeAboutMarkDownText from '!raw-loader!../../../README.md'
+import readMeAboutMarkDownText from '!raw-loader!../../../README.md';
 const marked = require('marked');
 
 export default {
-    name: 'About',
-    data() {
-        return {
-            readMeAboutMarkDownText,
-        }
-    },
-    computed: {
-        compiledMarkdown: function() {
-            return marked(readMeAboutMarkDownText, {santzie: true});
-        }
-    },
-}
+  name: 'About',
+  data() {
+    return {
+      readMeAboutMarkDownText
+    };
+  },
+  computed: {
+    compiledMarkdown: function() {
+      return marked(readMeAboutMarkDownText, { santzie: true });
+    }
+  }
+};
 </script>

--- a/vueapp/src/views/Settings.vue
+++ b/vueapp/src/views/Settings.vue
@@ -17,6 +17,11 @@
                 label="Voice"
                 v-model="selectedVoiceIndex"
               />
+ 
+              <v-switch
+                :label="customTilePad ? 'Custom Tile Pad' : 'Static Tile Pad'"
+                v-model="customTilePad"
+              />
             </v-col>
           </v-row>
         </v-container>
@@ -36,38 +41,55 @@
 </template>
 
 <script>
-import {mapActions, mapGetters} from 'vuex';
+import { mapActions, mapGetters } from 'vuex';
 
 const VOICES = window.speechSynthesis.getVoices();
 
-let voiceOptions = (VOICES.map((voice, index) => {
-    return {text: `${voice.name} (${voice.lang})`, value: index}
-})).sort((a,b) => a.text.localeCompare(b.text));
+let voiceOptions = VOICES.map((voice, index) => {
+  return { text: `${voice.name} (${voice.lang})`, value: index };
+}).sort((a, b) => a.text.localeCompare(b.text));
 
 export default {
-    
-    name:"Settings",
-    data () {
-        return {
-        dialog: true,
-        voiceOptions,
-        voices: VOICES
-        }      
+  name: 'Settings',
+  data() {
+    return {
+      dialog: true,
+      voiceOptions,
+      voices: VOICES
+    };
+  },
+  computed: {
+    ...mapGetters({
+      settingsDialogVisibility: 'settings/settingsDialogVisibility'
+    }),
+    selectedVoiceIndex: {
+      get() {
+        let voiceIndex = this.$store.state.settings.selectedVoiceIndex;
+        return voiceOptions.filter(x => x.value === voiceIndex)[0];
+      },
+      set(value) {
+        this.setSelectedVoiceIndex(value);
+      }
     },
-    computed: {
-        ...mapGetters(['settingsDialogVisibility']),
-        selectedVoiceIndex: {
-            get(){
-                let voiceIndex = this.$store.state.selectedVoiceIndex;
-                return voiceOptions.filter(x => x.value === voiceIndex)[0];
-            },
-            set(value){            
-                this.setselectedVoiceIndex(value);
-            }
-        }  
-        },
-        methods: {
-            ...mapActions(['setselectedVoiceIndex','toggleSettingsDialogVisibility'])
+    customTilePad: {
+      get(){
+        return this.$store.state.settings.customTilePad;
+      },
+      set(value){
+        if(!value){
+          this.setEditMode(false);
         }
-}
+        this.toggleCustomTilePad();
+      }
+    }
+  },
+  methods: {
+    ...mapActions({
+      setSelectedVoiceIndex: 'settings/setSelectedVoiceIndex',
+      toggleSettingsDialogVisibility: 'settings/toggleSettingsDialogVisibility',
+      toggleCustomTilePad: 'settings/toggleCustomTilePad',
+      setEditMode:'tilePad/setEditMode'
+    })
+  }
+};
 </script>

--- a/vueapp/src/views/TilePad.vue
+++ b/vueapp/src/views/TilePad.vue
@@ -18,6 +18,7 @@
           <Tile
             @speakText="speakText"
             :tile-data="tile"
+            :tile-page="currentTilePadPage"
           />
         </v-col>
       </template>
@@ -26,7 +27,7 @@
 </template>
 
 <script>
-import {mapGetters} from 'vuex';
+import { mapGetters, mapActions } from 'vuex';
 
 // object to access the speechSynthesis API
 const SPEECH_SYNTHESIS = window.speechSynthesis;
@@ -37,39 +38,60 @@ import Tile from '@/components/TilePad/Tile';
 import { isMobileOnly } from 'mobile-device-detect';
 
 export default {
-    name: 'TilePad',
-    components: {
-        Tile
-    },
-    data() {
-        return {
-            tileData: TileData,
-            isMobileOnly,
-            voices: VOICES
-        };
-    },
+  name: 'TilePad',
+  components: {
+    Tile
+  },
+  data() {
+    return {
+      tileData: TileData,
+      isMobileOnly,
+      voices: VOICES,
+    };
+  },
   computed: {
-      ...mapGetters(['selectedVoiceIndex']),
-      tilePadToDisplay: function(){
-        let routeParam = this.$route.params.layout
-        if(typeof routeParam === 'undefined'){
-          return this.tileData.home
-        }else{
-          return this.tileData[routeParam]
-        }
+    ...mapGetters({
+      selectedVoiceIndex: 'settings/selectedVoiceIndex',
+      customTilePadOption: 'settings/customTilePad',
+      customTilePadData: 'tilePad/customTilePadData'
+    }),
+    tilePadToDisplay: function() {
+      
+      //Checks to see if custom tile from store is empty, and if so sets the tile pad to the static one so they have something to start with, feel like there is a better way to prime the data.
+      if(Object.entries(this.customTilePadData).length === 0 && this.customTilePadData.constructor === Object){
+        this.setCustomTilePadData(this.tileData);
       }
+
+      let tilePadTiles = this.customTilePadOption ? this.customTilePadData : this.tileData;
+      
+      let routeParam = this.$route.params.layout;
+      if (typeof routeParam === 'undefined') {
+        return tilePadTiles.home;
+      } else {
+        return tilePadTiles[routeParam];
+      }
+    },
+    currentTilePadPage(){
+      let routeParam = this.$route.params.layout;
+      if (typeof routeParam === 'undefined') {
+        return 'home';
+      } else {
+        return routeParam;
+      }
+    }
   },
   methods: {
-      speakText(textToSpeak){
-          let speechSynthesisUtterance = new SpeechSynthesisUtterance(textToSpeak);
+    ...mapActions({
+      setCustomTilePadData : 'tilePad/setCustomTilePadData'
+    }),
+    speakText(textToSpeak) {
+      let speechSynthesisUtterance = new SpeechSynthesisUtterance(textToSpeak);
 
-          speechSynthesisUtterance.voice = this.voices[this.selectedVoiceIndex];
-          SPEECH_SYNTHESIS.speak(speechSynthesisUtterance);
-
-      }
+      speechSynthesisUtterance.voice = this.voices[this.selectedVoiceIndex];
+      SPEECH_SYNTHESIS.speak(speechSynthesisUtterance);
+    }
   }
 };
 </script>
 
-<style>
-</style>
+<style></style>

--- a/vueapp/vue.config.js
+++ b/vueapp/vue.config.js
@@ -1,11 +1,12 @@
 module.exports = {
-    'transpileDependencies': [
-        'vuetify'
-    ],
-    pwa: {
-        name: 'Freespeech',
-        themeColor: '#4DBA87',
-        msTileColor: '#000000',
-        appleMobileWebAppCapable: 'yes',
-      }
+  configureWebpack: {
+    devtool: 'source-map'
+  },
+  transpileDependencies: ['vuetify'],
+  pwa: {
+    name: 'Freespeech',
+    themeColor: '#4DBA87',
+    msTileColor: '#000000',
+    appleMobileWebAppCapable: 'yes'
+  }
 };


### PR DESCRIPTION
This adds the ability to have a keyboard with custom tiles. To use go to settings and turn on custom tiles. With this on if you click the pencil icon it changes the tile click to a edit. Once you are done and click the save icon you can click the tile again to speak and it saves the change.
If you want to go back to static mode, open settings and click the switch again.

This is just the initial pr with more features to be built on this. 