### PR TITLE
Chrome support for speechSynthesis

### DIFF
--- a/vueapp/package.json
+++ b/vueapp/package.json
@@ -1,87 +1,85 @@
 {
-  "name": "freespeechvue",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "test:unit": "vue-cli-service test:unit",
-    "lint": "vue-cli-service lint"
-  },
-  "dependencies": {
-    "core-js": "^2.6.5",
-    "marked": "^0.8.0",
-    "register-service-worker": "^1.6.2",
-    "vue": "^2.6.10",
-    "vue-router": "^3.0.3",
-    "vuetify": "^2.2.11",
-    "vuex": "^3.0.1",
-    "vuex-persist": "^2.2.0"
-  },
-  "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.12.0",
-    "@vue/cli-plugin-eslint": "^3.12.0",
-    "@vue/cli-plugin-pwa": "^4.2.2",
-    "@vue/cli-plugin-unit-mocha": "^4.2.2",
-    "@vue/cli-service": "^3.12.0",
-    "@vue/test-utils": "1.0.0-beta.31",
-    "babel-eslint": "^10.0.1",
-    "chai": "^4.1.2",
-    "eslint": "^5.16.0",
-    "eslint-plugin-vue": "^5.0.0",
-    "material-design-icons-iconfont": "^5.0.1",
-    "null-loader": "^3.0.0",
-    "raw-loader": "^4.0.0",
-    "sass": "^1.19.0",
-    "sass-loader": "^8.0.0",
-    "vue-cli-plugin-vuetify": "^2.0.5",
-    "vue-template-compiler": "^2.6.11",
-    "vuetify-loader": "^1.3.0"
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true
+    "name": "freespeechvue",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "serve": "vue-cli-service serve",
+        "build": "vue-cli-service build",
+        "test:unit": "vue-cli-service test:unit",
+        "lint": "vue-cli-service lint"
     },
-    "extends": [
-      "plugin:vue/strongly-recommended",
-      "eslint:recommended"
-    ],
-    "parserOptions": {
-      "parser": "babel-eslint"
+    "dependencies": {
+        "core-js": "^2.6.5",
+        "marked": "^0.8.0",
+        "register-service-worker": "^1.6.2",
+        "vue": "^2.6.10",
+        "vue-router": "^3.0.3",
+        "vuetify": "^2.2.11",
+        "vuex": "^3.0.1",
+        "vuex-persist": "^2.2.0"
     },
-    "rules": {
-      "quotes": [
-        2,
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        2,
-        "always"
-      ]
+    "devDependencies": {
+        "@vue/cli-plugin-babel": "^3.12.0",
+        "@vue/cli-plugin-eslint": "^3.12.0",
+        "@vue/cli-plugin-pwa": "^4.2.2",
+        "@vue/cli-plugin-unit-mocha": "^4.2.2",
+        "@vue/cli-service": "^3.12.0",
+        "@vue/test-utils": "1.0.0-beta.31",
+        "babel-eslint": "^10.0.1",
+        "chai": "^4.1.2",
+        "eslint": "^5.16.0",
+        "eslint-plugin-vue": "^5.0.0",
+        "material-design-icons-iconfont": "^5.0.1",
+        "null-loader": "^3.0.0",
+        "raw-loader": "^4.0.0",
+        "sass": "^1.19.0",
+        "sass-loader": "^8.0.0",
+        "vue-cli-plugin-vuetify": "^2.0.5",
+        "vue-template-compiler": "^2.6.11",
+        "vuetify-loader": "^1.3.0"
     },
-    "overrides": [
-      {
-        "files": [
-          "**/__tests__/*.{j,t}s?(x)",
-          "**/tests/unit/**/*.spec.{j,t}s?(x)"
-        ],
+    "eslintConfig": {
+        "root": true,
         "env": {
-          "mocha": true
+            "node": true
+        },
+        "extends": [
+            "plugin:vue/strongly-recommended",
+            "eslint:recommended"
+        ],
+        "parserOptions": {
+            "parser": "babel-eslint"
+        },
+        "rules": {
+            "quotes": [
+                2,
+                "single",
+                {
+                    "avoidEscape": true
+                }
+            ],
+            "semi": [
+                2,
+                "always"
+            ]
+        },
+        "overrides": [{
+            "files": [
+                "**/__tests__/*.{j,t}s?(x)",
+                "**/tests/unit/**/*.spec.{j,t}s?(x)"
+            ],
+            "env": {
+                "mocha": true
+            }
+        }]
+    },
+    "postcss": {
+        "plugins": {
+            "autoprefixer": {}
         }
-      }
+    },
+    "browserslist": [
+        "> 1%",
+        "last 2 versions"
     ]
-  },
-  "postcss": {
-    "plugins": {
-      "autoprefixer": {}
-    }
-  },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions"
-  ]
 }

--- a/vueapp/package.json
+++ b/vueapp/package.json
@@ -1,85 +1,87 @@
 {
-    "name": "freespeechvue",
-    "version": "0.1.0",
-    "private": true,
-    "scripts": {
-        "serve": "vue-cli-service serve",
-        "build": "vue-cli-service build",
-        "test:unit": "vue-cli-service test:unit",
-        "lint": "vue-cli-service lint"
+  "name": "freespeechvue",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "serve": "vue-cli-service serve",
+    "build": "vue-cli-service build",
+    "test:unit": "vue-cli-service test:unit",
+    "lint": "vue-cli-service lint"
+  },
+  "dependencies": {
+    "core-js": "^2.6.5",
+    "marked": "^0.8.0",
+    "register-service-worker": "^1.6.2",
+    "vue": "^2.6.10",
+    "vue-router": "^3.0.3",
+    "vuetify": "^2.2.11",
+    "vuex": "^3.0.1",
+    "vuex-persist": "^2.2.0"
+  },
+  "devDependencies": {
+    "@vue/cli-plugin-babel": "^3.12.0",
+    "@vue/cli-plugin-eslint": "^3.12.0",
+    "@vue/cli-plugin-pwa": "^4.2.2",
+    "@vue/cli-plugin-unit-mocha": "^4.2.2",
+    "@vue/cli-service": "^3.12.0",
+    "@vue/test-utils": "1.0.0-beta.31",
+    "babel-eslint": "^10.0.1",
+    "chai": "^4.1.2",
+    "eslint": "^5.16.0",
+    "eslint-plugin-vue": "^5.0.0",
+    "material-design-icons-iconfont": "^5.0.1",
+    "null-loader": "^3.0.0",
+    "raw-loader": "^4.0.0",
+    "sass": "^1.19.0",
+    "sass-loader": "^8.0.0",
+    "vue-cli-plugin-vuetify": "^2.0.5",
+    "vue-template-compiler": "^2.6.11",
+    "vuetify-loader": "^1.3.0"
+  },
+  "eslintConfig": {
+    "root": true,
+    "env": {
+      "node": true
     },
-    "dependencies": {
-        "core-js": "^2.6.5",
-        "marked": "^0.8.0",
-        "register-service-worker": "^1.6.2",
-        "vue": "^2.6.10",
-        "vue-router": "^3.0.3",
-        "vuetify": "^2.2.11",
-        "vuex": "^3.0.1",
-        "vuex-persist": "^2.2.0"
+    "extends": [
+      "plugin:vue/strongly-recommended",
+      "eslint:recommended"
+    ],
+    "parserOptions": {
+      "parser": "babel-eslint"
     },
-    "devDependencies": {
-        "@vue/cli-plugin-babel": "^3.12.0",
-        "@vue/cli-plugin-eslint": "^3.12.0",
-        "@vue/cli-plugin-pwa": "^4.2.2",
-        "@vue/cli-plugin-unit-mocha": "^4.2.2",
-        "@vue/cli-service": "^3.12.0",
-        "@vue/test-utils": "1.0.0-beta.31",
-        "babel-eslint": "^10.0.1",
-        "chai": "^4.1.2",
-        "eslint": "^5.16.0",
-        "eslint-plugin-vue": "^5.0.0",
-        "material-design-icons-iconfont": "^5.0.1",
-        "null-loader": "^3.0.0",
-        "raw-loader": "^4.0.0",
-        "sass": "^1.19.0",
-        "sass-loader": "^8.0.0",
-        "vue-cli-plugin-vuetify": "^2.0.5",
-        "vue-template-compiler": "^2.6.11",
-        "vuetify-loader": "^1.3.0"
-    },
-    "eslintConfig": {
-        "root": true,
-        "env": {
-            "node": true
-        },
-        "extends": [
-            "plugin:vue/strongly-recommended",
-            "eslint:recommended"
-        ],
-        "parserOptions": {
-            "parser": "babel-eslint"
-        },
-        "rules": {
-            "quotes": [
-                2,
-                "single",
-                {
-                    "avoidEscape": true
-                }
-            ],
-            "semi": [
-                2,
-                "always"
-            ]
-        },
-        "overrides": [{
-            "files": [
-                "**/__tests__/*.{j,t}s?(x)",
-                "**/tests/unit/**/*.spec.{j,t}s?(x)"
-            ],
-            "env": {
-                "mocha": true
-            }
-        }]
-    },
-    "postcss": {
-        "plugins": {
-            "autoprefixer": {}
+    "rules": {
+      "quotes": [
+        2,
+        "single",
+        {
+          "avoidEscape": true
         }
+      ],
+      "semi": [
+        2,
+        "always"
+      ]
     },
-    "browserslist": [
-        "> 1%",
-        "last 2 versions"
+    "overrides": [
+      {
+        "files": [
+          "**/__tests__/*.{j,t}s?(x)",
+          "**/tests/unit/**/*.spec.{j,t}s?(x)"
+        ],
+        "env": {
+          "mocha": true
+        }
+      }
     ]
+  },
+  "postcss": {
+    "plugins": {
+      "autoprefixer": {}
+    }
+  },
+  "browserslist": [
+    "> 1%",
+    "last 2 versions"
+  ]
 }

--- a/vueapp/src/App.vue
+++ b/vueapp/src/App.vue
@@ -77,15 +77,17 @@ export default {
     methods: {
     ...mapActions({        
       toggleSettingsDialogVisibility: 'settings/toggleSettingsDialogVisibility',
-      toggleEditMode: 'tilePad/toggleEditMode'
+      toggleEditMode: 'tilePad/toggleEditMode',
+      setVoices: 'settings/setVoices',
+      setVoiceOptions: 'settings/setVoiceOptions',
     }),
     populateVoiceData (windowVoices){
       const voiceOptions = windowVoices.map((voice, index) => {
         return { text: `${voice.name} (${voice.lang})`, value: index };
       }).sort((a, b) => a.text.localeCompare(b.text));
 
-      this.$store.dispatch('settings/setVoices', windowVoices);
-      this.$store.dispatch('settings/setVoiceOptions', voiceOptions);
+      this.setVoices(windowVoices);
+      this.setVoiceOptions(voiceOptions);
     },
   },
   computed: {

--- a/vueapp/src/App.vue
+++ b/vueapp/src/App.vue
@@ -78,7 +78,15 @@ export default {
     ...mapActions({        
       toggleSettingsDialogVisibility: 'settings/toggleSettingsDialogVisibility',
       toggleEditMode: 'tilePad/toggleEditMode'
-    })
+    }),
+    populateVoiceData (windowVoices){
+      const voiceOptions = windowVoices.map((voice, index) => {
+        return { text: `${voice.name} (${voice.lang})`, value: index };
+      }).sort((a, b) => a.text.localeCompare(b.text));
+
+      this.$store.dispatch('settings/setVoices', windowVoices);
+      this.$store.dispatch('settings/setVoiceOptions', voiceOptions);
+    },
   },
   computed: {
     ...mapGetters({ 
@@ -86,5 +94,15 @@ export default {
       editMode: 'tilePad/editMode'
     })
   },
+  created(){
+    let windowVoices = window.speechSynthesis.getVoices();
+
+    if (!windowVoices.length > 0) {
+      const vm = this;
+      window.speechSynthesis.onvoiceschanged = () => vm.populateVoiceData(window.speechSynthesis.getVoices());
+    } else {
+      this.populateVoiceData(windowVoices);
+    }
+  }
 };
 </script>

--- a/vueapp/src/store/modules/settings.js
+++ b/vueapp/src/store/modules/settings.js
@@ -9,43 +9,43 @@ const state = {
 
 const mutations = {
   SET_SELECTED_VOICE_INDEX(state, value) {
-      state.selectedVoiceIndex = value;
+    state.selectedVoiceIndex = value;
   },
   SET_VOICES(state, value) {
-      state.voices = value;
+    state.voices = value;
   },
   SET_VOICE_OPTIONS(state, value) {
-      state.voiceOptions = value;
+    state.voiceOptions = value;
   },
   TOGGLE_SETTINGS_DIALOG_VISIBILITY(state) {
-      state.settingsDialogVisibility = !state.settingsDialogVisibility;
+    state.settingsDialogVisibility = !state.settingsDialogVisibility;
   },
   TOGGLE_CUSTOM_TILE_PAD(state) {
-      state.customTilePad = !state.customTilePad;
+    state.customTilePad = !state.customTilePad;
   },
   TOGGLE_SENTENCE_MODE(state) {
-      state.sentenceMode = !state.sentenceMode;
+    state.sentenceMode = !state.sentenceMode;
   },
 };
 
 const actions = {
   toggleSentenceMode: ({ commit }) => {
-      commit('TOGGLE_SENTENCE_MODE');
+    commit('TOGGLE_SENTENCE_MODE');
   },
   setSelectedVoiceIndex: ({ commit }, value) => {
-      commit('SET_SELECTED_VOICE_INDEX', value);
+    commit('SET_SELECTED_VOICE_INDEX', value);
   },
   setVoices: ({ commit }, value) => {
-      commit('SET_VOICES', value);
+    commit('SET_VOICES', value);
   },
   setVoiceOptions: ({ commit }, value) => {
-      commit('SET_VOICE_OPTIONS', value);
+    commit('SET_VOICE_OPTIONS', value);
   },
   toggleSettingsDialogVisibility: ({ commit }) => {
-      commit('TOGGLE_SETTINGS_DIALOG_VISIBILITY');
+    commit('TOGGLE_SETTINGS_DIALOG_VISIBILITY');
   },
   toggleCustomTilePad: ({ commit }) => {
-      commit('TOGGLE_CUSTOM_TILE_PAD');
+    commit('TOGGLE_CUSTOM_TILE_PAD');
   }
 };
 

--- a/vueapp/src/store/modules/settings.js
+++ b/vueapp/src/store/modules/settings.js
@@ -1,49 +1,66 @@
 const state = {
-  selectedVoiceIndex: 0,
-  settingsDialogVisibility: false,
-  customTilePad: true,
-  sentenceMode: true
+    selectedVoiceIndex: 0,
+    voices: [],
+    voiceOptions: [],
+    settingsDialogVisibility: false,
+    customTilePad: true,
+    sentenceMode: true
 };
 
 const mutations = {
-  SET_SELECTED_VOICE_INDEX(state, value) {
-    state.selectedVoiceIndex = value;
-  },
-  TOGGLE_SETTINGS_DIALOG_VISIBILITY(state) {
-    state.settingsDialogVisibility = !state.settingsDialogVisibility;
-  },
-  TOGGLE_CUSTOM_TILE_PAD(state){
-    state.customTilePad = !state.customTilePad;
-  },
-  TOGGLE_SENTENCE_MODE(state){
-    state.sentenceMode = !state.sentenceMode;
-  },
+    SET_SELECTED_VOICE_INDEX(state, value) {
+        state.selectedVoiceIndex = value;
+    },
+    SET_VOICES(state, value) {
+        state.voices = value;
+    },
+    SET_VOICE_OPTIONS(state, value) {
+        state.voiceOptions = value;
+    },
+    TOGGLE_SETTINGS_DIALOG_VISIBILITY(state) {
+        state.settingsDialogVisibility = !state.settingsDialogVisibility;
+    },
+    TOGGLE_CUSTOM_TILE_PAD(state) {
+        state.customTilePad = !state.customTilePad;
+    },
+    TOGGLE_SENTENCE_MODE(state) {
+        state.sentenceMode = !state.sentenceMode;
+    },
 };
 
 const actions = {
-  toggleSentenceMode: ({commit}) => {
-    commit('TOGGLE_SENTENCE_MODE');
-  },
-  setSelectedVoiceIndex: ({ commit }, value) => {
-    commit('SET_SELECTED_VOICE_INDEX', value);
-  },
-  toggleSettingsDialogVisibility: ({ commit }) => {
-    commit('TOGGLE_SETTINGS_DIALOG_VISIBILITY');
-  },
-  toggleCustomTilePad: ({commit}) => {
-    commit('TOGGLE_CUSTOM_TILE_PAD');
-  }
+    toggleSentenceMode: ({ commit }) => {
+        commit('TOGGLE_SENTENCE_MODE');
+    },
+    setSelectedVoiceIndex: ({ commit }, value) => {
+        commit('SET_SELECTED_VOICE_INDEX', value);
+    },
+    setVoices: ({ commit }, value) => {
+        commit('SET_VOICES', value);
+    },
+    setVoiceOptions: ({ commit }, value) => {
+        commit('SET_VOICE_OPTIONS', value);
+    },
+    toggleSettingsDialogVisibility: ({ commit }) => {
+        commit('TOGGLE_SETTINGS_DIALOG_VISIBILITY');
+    },
+    toggleCustomTilePad: ({ commit }) => {
+        commit('TOGGLE_CUSTOM_TILE_PAD');
+    }
 };
 
 const getters = {
-  settingsDialogVisibility: state => state.settingsDialogVisibility,
-  selectedVoiceIndex: state => state.selectedVoiceIndex,
-  customTilePad: state => state.customTilePad
+    settingsDialogVisibility: state => state.settingsDialogVisibility,
+    selectedVoiceIndex: state => state.selectedVoiceIndex,
+    customTilePad: state => state.customTilePad,
+    voices: state => state.voices,
+    voiceOptions: state => state.voiceOptions,
 };
+
 export default {
-  namespaced: true,
-  state,
-  mutations,
-  actions,
-  getters
+    namespaced: true,
+    state,
+    mutations,
+    actions,
+    getters
 };

--- a/vueapp/src/store/modules/settings.js
+++ b/vueapp/src/store/modules/settings.js
@@ -8,43 +8,43 @@ const state = {
 };
 
 const mutations = {
-  SET_SELECTED_VOICE_INDEX(state, value) {
+  SET_SELECTED_VOICE_INDEX(state, value){
     state.selectedVoiceIndex = value;
   },
-  SET_VOICES(state, value) {
+  SET_VOICES(state, value){
     state.voices = value;
   },
-  SET_VOICE_OPTIONS(state, value) {
+  SET_VOICE_OPTIONS(state, value){
     state.voiceOptions = value;
   },
-  TOGGLE_SETTINGS_DIALOG_VISIBILITY(state) {
+  TOGGLE_SETTINGS_DIALOG_VISIBILITY(state){
     state.settingsDialogVisibility = !state.settingsDialogVisibility;
   },
-  TOGGLE_CUSTOM_TILE_PAD(state) {
+  TOGGLE_CUSTOM_TILE_PAD(state){
     state.customTilePad = !state.customTilePad;
   },
-  TOGGLE_SENTENCE_MODE(state) {
+  TOGGLE_SENTENCE_MODE(state){
     state.sentenceMode = !state.sentenceMode;
   },
 };
 
 const actions = {
-  toggleSentenceMode: ({ commit }) => {
+  toggleSentenceMode: ({commit}) => {
     commit('TOGGLE_SENTENCE_MODE');
   },
-  setSelectedVoiceIndex: ({ commit }, value) => {
+  setSelectedVoiceIndex: ({commit}, value) => {
     commit('SET_SELECTED_VOICE_INDEX', value);
   },
-  setVoices: ({ commit }, value) => {
+  setVoices: ({commit}, value) => {
     commit('SET_VOICES', value);
   },
-  setVoiceOptions: ({ commit }, value) => {
+  setVoiceOptions: ({commit}, value) => {
     commit('SET_VOICE_OPTIONS', value);
   },
-  toggleSettingsDialogVisibility: ({ commit }) => {
+  toggleSettingsDialogVisibility: ({commit}) => {
     commit('TOGGLE_SETTINGS_DIALOG_VISIBILITY');
   },
-  toggleCustomTilePad: ({ commit }) => {
+  toggleCustomTilePad: ({commit}) => {
     commit('TOGGLE_CUSTOM_TILE_PAD');
   }
 };

--- a/vueapp/src/store/modules/settings.js
+++ b/vueapp/src/store/modules/settings.js
@@ -1,66 +1,66 @@
 const state = {
-    selectedVoiceIndex: 0,
-    voices: [],
-    voiceOptions: [],
-    settingsDialogVisibility: false,
-    customTilePad: true,
-    sentenceMode: true
+  selectedVoiceIndex: 0,
+  voices: [],
+  voiceOptions: [],
+  settingsDialogVisibility: false,
+  customTilePad: true,
+  sentenceMode: true
 };
 
 const mutations = {
-    SET_SELECTED_VOICE_INDEX(state, value) {
-        state.selectedVoiceIndex = value;
-    },
-    SET_VOICES(state, value) {
-        state.voices = value;
-    },
-    SET_VOICE_OPTIONS(state, value) {
-        state.voiceOptions = value;
-    },
-    TOGGLE_SETTINGS_DIALOG_VISIBILITY(state) {
-        state.settingsDialogVisibility = !state.settingsDialogVisibility;
-    },
-    TOGGLE_CUSTOM_TILE_PAD(state) {
-        state.customTilePad = !state.customTilePad;
-    },
-    TOGGLE_SENTENCE_MODE(state) {
-        state.sentenceMode = !state.sentenceMode;
-    },
+  SET_SELECTED_VOICE_INDEX(state, value) {
+      state.selectedVoiceIndex = value;
+  },
+  SET_VOICES(state, value) {
+      state.voices = value;
+  },
+  SET_VOICE_OPTIONS(state, value) {
+      state.voiceOptions = value;
+  },
+  TOGGLE_SETTINGS_DIALOG_VISIBILITY(state) {
+      state.settingsDialogVisibility = !state.settingsDialogVisibility;
+  },
+  TOGGLE_CUSTOM_TILE_PAD(state) {
+      state.customTilePad = !state.customTilePad;
+  },
+  TOGGLE_SENTENCE_MODE(state) {
+      state.sentenceMode = !state.sentenceMode;
+  },
 };
 
 const actions = {
-    toggleSentenceMode: ({ commit }) => {
-        commit('TOGGLE_SENTENCE_MODE');
-    },
-    setSelectedVoiceIndex: ({ commit }, value) => {
-        commit('SET_SELECTED_VOICE_INDEX', value);
-    },
-    setVoices: ({ commit }, value) => {
-        commit('SET_VOICES', value);
-    },
-    setVoiceOptions: ({ commit }, value) => {
-        commit('SET_VOICE_OPTIONS', value);
-    },
-    toggleSettingsDialogVisibility: ({ commit }) => {
-        commit('TOGGLE_SETTINGS_DIALOG_VISIBILITY');
-    },
-    toggleCustomTilePad: ({ commit }) => {
-        commit('TOGGLE_CUSTOM_TILE_PAD');
-    }
+  toggleSentenceMode: ({ commit }) => {
+      commit('TOGGLE_SENTENCE_MODE');
+  },
+  setSelectedVoiceIndex: ({ commit }, value) => {
+      commit('SET_SELECTED_VOICE_INDEX', value);
+  },
+  setVoices: ({ commit }, value) => {
+      commit('SET_VOICES', value);
+  },
+  setVoiceOptions: ({ commit }, value) => {
+      commit('SET_VOICE_OPTIONS', value);
+  },
+  toggleSettingsDialogVisibility: ({ commit }) => {
+      commit('TOGGLE_SETTINGS_DIALOG_VISIBILITY');
+  },
+  toggleCustomTilePad: ({ commit }) => {
+      commit('TOGGLE_CUSTOM_TILE_PAD');
+  }
 };
 
 const getters = {
-    settingsDialogVisibility: state => state.settingsDialogVisibility,
-    selectedVoiceIndex: state => state.selectedVoiceIndex,
-    customTilePad: state => state.customTilePad,
-    voices: state => state.voices,
-    voiceOptions: state => state.voiceOptions,
+  settingsDialogVisibility: state => state.settingsDialogVisibility,
+  selectedVoiceIndex: state => state.selectedVoiceIndex,
+  customTilePad: state => state.customTilePad,
+  voices: state => state.voices,
+  voiceOptions: state => state.voiceOptions,
 };
 
 export default {
-    namespaced: true,
-    state,
-    mutations,
-    actions,
-    getters
+  namespaced: true,
+  state,
+  mutations,
+  actions,
+  getters
 };

--- a/vueapp/src/views/Settings.vue
+++ b/vueapp/src/views/Settings.vue
@@ -48,19 +48,12 @@
 <script>
 import { mapActions, mapGetters } from 'vuex';
 
-const VOICES = window.speechSynthesis.getVoices();
-
-let voiceOptions = VOICES.map((voice, index) => {
-  return { text: `${voice.name} (${voice.lang})`, value: index };
-}).sort((a, b) => a.text.localeCompare(b.text));
-
 export default {
   name: 'Settings',
   data() {
     return {
       dialog: true,
-      voiceOptions,
-      voices: VOICES,
+      voiceOptions: [],
     };
   },
   computed: {
@@ -70,7 +63,7 @@ export default {
     selectedVoiceIndex: {
       get() {
         let voiceIndex = this.$store.state.settings.selectedVoiceIndex;
-        return voiceOptions.filter(x => x.value === voiceIndex)[0];
+        return this.voiceOptions.filter(x => x.value === voiceIndex)[0];
       },
       set(value) {
         this.setSelectedVoiceIndex(value);
@@ -103,7 +96,22 @@ export default {
       toggleCustomTilePad: 'settings/toggleCustomTilePad',
       setEditMode:'tilePad/setEditMode',
       toggleSentenceMode: 'settings/toggleSentenceMode'
-    })
-  }
+    }),
+    populateVoiceData (windowVoices){
+      this.voiceOptions = windowVoices.map((voice, index) => {
+        return { text: `${voice.name} (${voice.lang})`, value: index };
+      }).sort((a, b) => a.text.localeCompare(b.text));
+    },
+  },
+  created() {
+    let windowVoices = window.speechSynthesis.getVoices();
+
+    if (!windowVoices.length > 0) {
+      const vm = this;
+      window.speechSynthesis.onvoiceschanged = () => vm.populateVoiceData(window.speechSynthesis.getVoices());
+    } else {
+      this.populateVoiceData(windowVoices);
+    }
+  },
 };
 </script>

--- a/vueapp/src/views/Settings.vue
+++ b/vueapp/src/views/Settings.vue
@@ -13,7 +13,7 @@
           <v-row>
             <v-col cols="12">
               <v-select
-                :items="$store.state.settings.voiceOptions"
+                :items="voiceOptions"
                 label="Voice"
                 v-model="selectedVoiceIndex"
               />

--- a/vueapp/src/views/Settings.vue
+++ b/vueapp/src/views/Settings.vue
@@ -13,7 +13,7 @@
           <v-row>
             <v-col cols="12">
               <v-select
-                :items="voiceOptions"
+                :items="$store.state.settings.voiceOptions"
                 label="Voice"
                 v-model="selectedVoiceIndex"
               />
@@ -53,12 +53,12 @@ export default {
   data() {
     return {
       dialog: true,
-      voiceOptions: [],
     };
   },
   computed: {
     ...mapGetters({
-      settingsDialogVisibility: 'settings/settingsDialogVisibility'
+      settingsDialogVisibility: 'settings/settingsDialogVisibility',
+      voiceOptions: 'settings/voiceOptions',
     }),
     selectedVoiceIndex: {
       get() {
@@ -97,21 +97,6 @@ export default {
       setEditMode:'tilePad/setEditMode',
       toggleSentenceMode: 'settings/toggleSentenceMode'
     }),
-    populateVoiceData (windowVoices){
-      this.voiceOptions = windowVoices.map((voice, index) => {
-        return { text: `${voice.name} (${voice.lang})`, value: index };
-      }).sort((a, b) => a.text.localeCompare(b.text));
-    },
-  },
-  created() {
-    let windowVoices = window.speechSynthesis.getVoices();
-
-    if (!windowVoices.length > 0) {
-      const vm = this;
-      window.speechSynthesis.onvoiceschanged = () => vm.populateVoiceData(window.speechSynthesis.getVoices());
-    } else {
-      this.populateVoiceData(windowVoices);
-    }
   },
 };
 </script>

--- a/vueapp/src/views/TilePad.vue
+++ b/vueapp/src/views/TilePad.vue
@@ -48,7 +48,6 @@ import { mapGetters, mapActions, mapState } from 'vuex';
 
 // object to access the speechSynthesis API
 const SPEECH_SYNTHESIS = window.speechSynthesis;
-const VOICES = SPEECH_SYNTHESIS.getVoices();
 
 import TileData from '../../../build.json';
 import Tile from '@/components/TilePad/Tile';
@@ -63,8 +62,7 @@ export default {
   data() {
     return {
       tileData: TileData,
-      voices: VOICES,
-      sentenceTiles: []
+      sentenceTiles: [],
     };
   },
   computed: {
@@ -72,7 +70,8 @@ export default {
     ...mapGetters({
       selectedVoiceIndex: 'settings/selectedVoiceIndex',
       customTilePadOption: 'settings/customTilePad',
-      customTilePadData: 'tilePad/customTilePadData'
+      customTilePadData: 'tilePad/customTilePadData',
+      voices: 'settings/voices',
     }),
     tilePadToDisplay: function() {
       //Checks to see if custom tile from store is empty, and if so sets the tile pad to the static one so they have something to start with, feel like there is a better way to prime the data.


### PR DESCRIPTION
Fixes #21 

- Moved available voices and voice information into the store to be shared across Settings.vue and TilePad.vue
- Using window.speechSynthesis.onvoiceschanged in App.vue if speechSynthesis.getVoices() returns an empty array.