### PR TITLE
can rearrange the tiles

### DIFF
--- a/vueapp/package-lock.json
+++ b/vueapp/package-lock.json
@@ -11326,6 +11326,11 @@
         "is-plain-obj": "^1.0.0"
       }
     },
+    "sortablejs": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+      "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -12545,6 +12550,14 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vuedraggable": {
+      "version": "2.23.2",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.23.2.tgz",
+      "integrity": "sha512-PgHCjUpxEAEZJq36ys49HfQmXglattf/7ofOzUrW2/rRdG7tu6fK84ir14t1jYv4kdXewTEa2ieKEAhhEMdwkQ==",
+      "requires": {
+        "sortablejs": "^1.10.1"
+      }
     },
     "vuetify": {
       "version": "2.2.12",

--- a/vueapp/package.json
+++ b/vueapp/package.json
@@ -14,6 +14,7 @@
     "register-service-worker": "^1.6.2",
     "vue": "^2.6.10",
     "vue-router": "^3.0.3",
+    "vuedraggable": "^2.23.2",
     "vuetify": "^2.2.11",
     "vuex": "^3.0.1",
     "vuex-persist": "^2.2.0"

--- a/vueapp/src/views/TilePad.vue
+++ b/vueapp/src/views/TilePad.vue
@@ -12,32 +12,35 @@
       class="grey lighten-5 pb-10"
       style="{text-align: center}"
     >
-      <v-row
-        dense
-        v-for="(row, index) in tilePadToDisplay"
-        :key="index"
-        class="tilePadContainer"
-      >
-        <template v-for="(tile, tileIndex) in row">
-          <v-col
-            :key="tileIndex"
-            :cols="
-              $vuetify.breakpoint.xsOnly
-                ? 3
-                : $vuetify.breakpoint.smAndDown
-                  ? 2
-                  : 1
-            "
-            class="d-flex child-flex"
-          >
-            <Tile
-              @speakText="speakText"
-              @addToSentence="sentenceTiles.push($event)"
-              :tile-data="tile"
-              :tile-page="currentTilePadPage"
-            />
-          </v-col>
-        </template>
+      <v-row dense>
+        <draggable
+          style="display: contents"
+          v-model="tilePadToDisplay.tileData"
+          :options="{disabled: !editMode}"
+          class="tilePadContainer"
+        >
+          <template v-for="(tile, tileIndex) in tilePadToDisplay.tileData">
+            <v-col
+              :key="tileIndex"
+              :cols="
+                $vuetify.breakpoint.xsOnly
+                  ? 3
+                  : $vuetify.breakpoint.smAndDown
+                    ? 2
+                    : 1
+              "
+              class="d-flex child-flex"
+              style="padding: 4px"
+            >
+              <Tile
+                @speakText="speakText"
+                @addToSentence="sentenceTiles.push($event)"
+                :tile-data="tile"
+                :tile-page="currentTilePadPage"
+              />
+            </v-col>
+          </template>
+        </draggable>
       </v-row>
     </v-container>
   </div>
@@ -45,6 +48,7 @@
 
 <script>
 import { mapGetters, mapActions, mapState } from 'vuex';
+import draggable from 'vuedraggable';
 
 // object to access the speechSynthesis API
 const SPEECH_SYNTHESIS = window.speechSynthesis;
@@ -57,21 +61,23 @@ export default {
   name: 'TilePad',
   components: {
     Tile,
-    Sentence
+    Sentence,
+    draggable
   },
   data() {
     return {
       tileData: TileData,
-      sentenceTiles: [],
+      sentenceTiles: []
     };
   },
   computed: {
     ...mapState('settings', ['sentenceMode']),
+    ...mapState('tilePad', ['editMode']),
     ...mapGetters({
       selectedVoiceIndex: 'settings/selectedVoiceIndex',
       customTilePadOption: 'settings/customTilePad',
       customTilePadData: 'tilePad/customTilePadData',
-      voices: 'settings/voices',
+      voices: 'settings/voices'
     }),
     tilePadToDisplay: function() {
       //Checks to see if custom tile from store is empty, and if so sets the tile pad to the static one so they have something to start with, feel like there is a better way to prime the data.


### PR DESCRIPTION
When in edit mode you can now rearrange the icons by dragging them. This closes #31 if the other tile customizations are in #34. It would benefit from #47 and #43 because the UI is a bit odd. 