### PR TITLE
Add better edit mode differentiation.

### DIFF
--- a/vueapp/src/App.vue
+++ b/vueapp/src/App.vue
@@ -2,7 +2,7 @@
   <v-app>
     <v-app-bar
       app
-      color="primary"
+      :color="taskbarColor"
       dark
     >
       <div class="d-flex align-center">
@@ -36,6 +36,7 @@
       <v-btn
         icon
         to="/about"
+        @click="this.disableEditMode"
       >
         <v-icon>
           info
@@ -75,7 +76,7 @@ export default {
     //
   }),
     methods: {
-    ...mapActions({        
+    ...mapActions({
       toggleSettingsDialogVisibility: 'settings/toggleSettingsDialogVisibility',
       toggleEditMode: 'tilePad/toggleEditMode',
       setVoices: 'settings/setVoices',
@@ -89,12 +90,18 @@ export default {
       this.setVoices(windowVoices);
       this.setVoiceOptions(voiceOptions);
     },
+    disableEditMode() {
+      this.$store.dispatch('tilePad/setEditMode', false);
+    }
   },
   computed: {
-    ...mapGetters({ 
+    ...mapGetters({
       customTilePad: 'settings/customTilePad',
       editMode: 'tilePad/editMode'
-    })
+    }),
+    taskbarColor() {
+      return this.editMode ? 'success' : 'primary';
+    }
   },
   created(){
     let windowVoices = window.speechSynthesis.getVoices();

--- a/vueapp/src/components/EditModeHeader/EditModeHeader.vue
+++ b/vueapp/src/components/EditModeHeader/EditModeHeader.vue
@@ -21,7 +21,8 @@
         <p
           class="body-2"
         >
-          You can edit tiles while in edit mode by clicking on them to edit them. Press the save icon or the button above to save your changes.
+          You can edit tiles while in edit mode by clicking on them to edit them or clicking and dragging them to move them around.
+          Press the save icon or the button above to save your changes.
         </p>
       </v-container>
     </v-card>

--- a/vueapp/src/components/EditModeHeader/EditModeHeader.vue
+++ b/vueapp/src/components/EditModeHeader/EditModeHeader.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="sentenceCardContainer grey lighten-5">
+    <v-card
+      outlined
+      class="px-4 sentenceCard"
+    >
+      <v-card-title>
+        You're in edit mode!
+        <v-spacer />
+        <v-btn
+          class="mx-2"
+          color="success"
+          @click="exitEditMode"
+        >
+          <v-icon class="pr-2">
+            save
+          </v-icon> Save Changes
+        </v-btn>
+      </v-card-title>
+      <v-container class="py-0">
+        <p
+          class="body-2"
+        >
+          You can edit tiles while in edit mode by clicking on them to edit them. Press the save icon or the button above to save your changes.
+        </p>
+      </v-container>
+    </v-card>
+  </div>
+</template>
+
+<script>
+export default {
+  methods: {
+    exitEditMode() {
+      this.$store.dispatch('tilePad/setEditMode', false);
+    }
+  }
+};
+</script>
+<style scoped>
+.sentenceCardContainer {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 56px;
+  z-index: 100;
+  padding: 5px;
+  background-color: white;
+}
+</style>

--- a/vueapp/src/views/TilePad.vue
+++ b/vueapp/src/views/TilePad.vue
@@ -59,6 +59,7 @@ const SPEECH_SYNTHESIS = window.speechSynthesis;
 import TileData from '../../../build.json';
 import Tile from '@/components/TilePad/Tile';
 import Sentence from '@/components/Sentence/Sentence';
+import EditModeHeader from '@/components/EditModeHeader/EditModeHeader';
 
 export default {
   name: 'TilePad',

--- a/vueapp/src/views/TilePad.vue
+++ b/vueapp/src/views/TilePad.vue
@@ -1,11 +1,14 @@
 <template>
   <div>
     <Sentence
-      v-if="sentenceMode"
+      v-if="sentenceMode && !editMode"
       :tile-pad-to-display="sentenceTiles"
       @clearSentence="sentenceTiles = []"
       @speakSentence="speakSentence"
       @removeFromSentence="sentenceTiles.splice($event, 1)"
+    />
+    <edit-mode-header
+      v-if="sentenceMode && editMode"
     />
     <v-container
       fluid
@@ -52,12 +55,14 @@ const SPEECH_SYNTHESIS = window.speechSynthesis;
 import TileData from '../../../build.json';
 import Tile from '@/components/TilePad/Tile';
 import Sentence from '@/components/Sentence/Sentence';
+import EditModeHeader from '@/components/EditModeHeader/EditModeHeader';
 
 export default {
   name: 'TilePad',
   components: {
     Tile,
-    Sentence
+    Sentence,
+    EditModeHeader
   },
   data() {
     return {
@@ -71,6 +76,7 @@ export default {
       selectedVoiceIndex: 'settings/selectedVoiceIndex',
       customTilePadOption: 'settings/customTilePad',
       customTilePadData: 'tilePad/customTilePadData',
+      editMode: 'tilePad/editMode',
       voices: 'settings/voices',
     }),
     tilePadToDisplay: function() {


### PR DESCRIPTION
Really like the project so far, so I thought I'd contribute!

This pull request adds better edit mode differentiation by adding a few small features, and cleans up existing code just a little bit.

When I first tested out the app, I found it hard to understand whether I was in edit mode or not (I didn't realize the icon in the corner changed), so I decided to add a few indicators to make sure that the user knows they're in edit mode and understands _how_ to actually edit the tiles. 

Changes made include:

* The taskbar now changes from 'primary' to 'success' when in edit mode.
* Improved the rendering of the taskbar edit mode button by combining the icons inside of a single button and rendering them conditionally.
* When a user switches to another route (the only other route in the app lol) the app exits edit mode.
* While in edit mode, instead of displaying the usual sentences view, a new view (called "EditModeHeader" for right now) is displayed. It's basically the same as the sentences component, just with a save button and some text that explains how to edit things while in edit mode (and how to exit).

Also don't really know why the preview rendered so weird on GitHub. 🤷‍♂ 