### PR TITLE
Preview voice

### DIFF
--- a/vueapp/src/views/Settings.vue
+++ b/vueapp/src/views/Settings.vue
@@ -57,6 +57,7 @@ export default {
     ...mapGetters({
       passcode: 'settings/passcode',
       voiceOptions: 'settings/voiceOptions',
+      voices: 'settings/voices'
     }),
     selectedVoiceIndex: {
       get() {
@@ -65,6 +66,9 @@ export default {
       },
       set(value) {
         this.setSelectedVoiceIndex(value);
+        const speechSynthesisUtterance = new SpeechSynthesisUtterance('Welcome to Free Speech');
+        speechSynthesisUtterance.voice = this.voices[value];
+        window.speechSynthesis.speak(speechSynthesisUtterance);
       }
     },
     customTilePad: {


### PR DESCRIPTION
The great idea by @HunterM417 in #17, reimplemented for refactored settings page.

Have changed it to preview as soon as voice is selected, as I felt the button might be an unnecessary step.