### PR TITLE
Prevent senteces to queue up on multiple clicks

### DIFF
--- a/vueapp/src/views/TilePad.vue
+++ b/vueapp/src/views/TilePad.vue
@@ -128,6 +128,7 @@ export default {
 			logTileTap: 'tilePad/logTileTap',
 		}),
 		speakText (textToSpeak) {
+			SPEECH_SYNTHESIS.cancel();
 			let speechSynthesisUtterance = new SpeechSynthesisUtterance(textToSpeak);
 
 			speechSynthesisUtterance.voice = this.voices[this.selectedVoiceIndex];


### PR DESCRIPTION
If user clicks on Speak button current sentence being played  will be cancelled and it will start over, this ways sentence cannot be queued up to speak multiple times. 