### PR TITLE
Surface swallowed errors in page/project modals

### DIFF
--- a/src/components/modals/CreatePageModal.svelte
+++ b/src/components/modals/CreatePageModal.svelte
@@ -12,7 +12,13 @@
 	const createPage = async () => {
 		if (creatingPage) return;
 		creatingPage = true;
-		await api.page.create({ projectId, name: pageName });
+
+		const response = await api.page.create({ projectId, name: pageName });
+
+		if (response.error) {
+			creatingPage = false;
+			return alert(response.error);
+		}
 
 		// Refresh the pages list
 		const { pages } = await api.project.listPages(projectId);

--- a/src/components/modals/EditPageModal.svelte
+++ b/src/components/modals/EditPageModal.svelte
@@ -6,9 +6,12 @@
 
 	const editPage = async () => {
 		if (!$PageBeingEdited) return;
-		await api.page.edit($PageBeingEdited.id, {
+		const response = await api.page.edit($PageBeingEdited.id, {
 			name: $PageBeingEdited.name
 		});
+
+		if (response.error) return alert(response.error);
+
 		await invalidateAll();
 		requestBoardRefresh();
 		$PageBeingEdited = null;

--- a/src/components/modals/EditPagesModal.svelte
+++ b/src/components/modals/EditPagesModal.svelte
@@ -29,7 +29,9 @@
 	}
 
 	const deletePage = async (pageId: string) => {
-		await api.page.delete(pageId);
+		const response = await api.page.delete(pageId);
+
+		if (response.error) return alert(response.error);
 
 		if ($page.url.pathname.includes(pageId)) window.location.assign(`/app/project/${projectId}`);
 

--- a/src/components/modals/EditProjectsModal.svelte
+++ b/src/components/modals/EditProjectsModal.svelte
@@ -8,7 +8,10 @@
 	export let projects: Project[];
 
 	const deleteProject = async (projectId: string) => {
-		await api.project.delete(projectId);
+		const response = await api.project.delete(projectId);
+
+		if (response.error) return alert(response.error);
+
 		await invalidateAll();
 	};
 </script>


### PR DESCRIPTION
## Why

Several modals discarded their API response (which carries `{ error }` as HTTP 200), so validation/server errors produced **no feedback** — the modal just closed as if it had succeeded.

Covered here:
- **Create page** (`CreatePageModal`) — duplicate/invalid name silently did nothing.
- **Rename page** (`EditPageModal`) — errors swallowed.
- **Delete page** (`EditPagesModal`) — errors swallowed **and** the page was removed from the store unconditionally, so a failed delete (e.g. the home page) vanished from the UI until a refresh.
- **Delete project** (`EditProjectsModal`) — errors swallowed.

## What

Each now captures the response, `alert()`s `response.error`, and bails **before** mutating any store / closing the modal — matching the existing pattern in the project create/edit modals. Create/rename keep the modal open so the user can fix the name and retry.

Pairs with freespeech-api changes: duplicate-name validation now also runs on page **rename** (previously only on create).

## Verification

Built (Vite/adapter-node) and deployed to freespeechaac.com; service healthy (HTTP 200 on :5105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)