### PR TITLE
Improve page management UX (inline rename, home page, delete confirm)

### DIFF
--- a/src/components/modals/EditPagesModal.svelte
+++ b/src/components/modals/EditPagesModal.svelte
@@ -14,6 +14,10 @@
 
 	export let pages: TilePage[];
 	export let projectId: string;
+	export let homePageId: string | null = null;
+
+	let confirmingDeleteId: string | null = null;
+	let busy = false;
 
 	// Fetch pages when modal opens if not already loaded
 	$: if ($EditingPages && pages.length === 0 && !$ProjectPagesLoading) {
@@ -28,8 +32,29 @@
 		})();
 	}
 
+	const setHomePage = async (pageId: string) => {
+		if (busy) return;
+		busy = true;
+		const response = await api.project.edit(projectId, { homePageId: pageId });
+		busy = false;
+
+		if (response.error) return alert(response.error);
+
+		await invalidateAll();
+		requestBoardRefresh();
+	};
+
+	const renamePage = (p: TilePage) => {
+		$PageBeingEdited = { ...p };
+		$EditingPages = false;
+	};
+
 	const deletePage = async (pageId: string) => {
+		if (busy) return;
+		busy = true;
 		const response = await api.page.delete(pageId);
+		busy = false;
+		confirmingDeleteId = null;
 
 		if (response.error) return alert(response.error);
 
@@ -43,37 +68,78 @@
 </script>
 
 {#if $EditingPages}
-	<ModalShell closeModal={() => ($EditingPages = false)} title="Pages">
+	<ModalShell
+		closeModal={() => {
+			$EditingPages = false;
+			confirmingDeleteId = null;
+		}}
+		title="Pages"
+	>
 		{#if $ProjectPagesLoading}
 			<p class="text-zinc-400">Loading pages...</p>
 		{:else}
-			{#each pages as page, index (page.id)}
-			<div
-				class={`flex items-center gap-2 py-2 ${
-					index !== 0 ? 'border border-x-0 border-b-0 border-zinc-700' : ''
-				}`}
-			>
-				<p>{page.name}</p>
-				<div class="flex-1" />
-				<a
-					href={`/app/project/${projectId}/${page.id}`}
-					class="rounded-md border border-blue-500 bg-blue-600 p-1 px-2 text-sm">View</a
-				>
-				{#if page.name !== 'Home'}
-					<button
-						on:click={() => {
-							$PageBeingEdited = { ...page };
-							$EditingPages = false;
-						}}
-						class="rounded-md border border-yellow-500 bg-yellow-600 p-1 px-2 text-sm">Edit</button
+			<div class="flex flex-col gap-2">
+				{#each pages as p (p.id)}
+					<div
+						class="flex items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-800/40 px-3 py-2"
 					>
-					<button
-						on:click={() => deletePage(page.id)}
-						class="rounded-md border border-red-500 bg-red-600 p-1 px-2 text-sm">Delete</button
-					>
-				{/if}
+						<div class="flex min-w-0 flex-1 items-center gap-2">
+							{#if p.id === homePageId}
+								<i class="bi bi-house-door-fill text-blue-400" />
+							{/if}
+							<span class="truncate">{p.name}</span>
+							{#if p.id === homePageId}
+								<span
+									class="rounded-full bg-blue-600/20 px-2 py-0.5 text-xs font-medium text-blue-300"
+									>Home</span
+								>
+							{/if}
+						</div>
+
+						{#if confirmingDeleteId === p.id}
+							<div class="flex shrink-0 items-center gap-2">
+								<span class="text-sm text-zinc-400">Delete page?</span>
+								<button
+									on:click={() => deletePage(p.id)}
+									disabled={busy}
+									class="rounded-md border border-red-500 bg-red-600 p-1 px-2 text-sm disabled:opacity-50"
+									>Yes</button
+								>
+								<button
+									on:click={() => (confirmingDeleteId = null)}
+									class="rounded-md border border-zinc-600 bg-zinc-700 p-1 px-2 text-sm">No</button
+								>
+							</div>
+						{:else}
+							<div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
+								<a
+									href={`/app/project/${projectId}/${p.id}`}
+									class="rounded-md border border-blue-500 bg-blue-600 p-1 px-2 text-sm">View</a
+								>
+								{#if p.id !== homePageId}
+									<button
+										on:click={() => setHomePage(p.id)}
+										disabled={busy}
+										title="Set as home page"
+										class="flex items-center gap-1 rounded-md border border-zinc-600 bg-zinc-700 p-1 px-2 text-sm disabled:opacity-50"
+									>
+										<i class="bi bi-house-door text-xs" />Set Home
+									</button>
+									<button
+										on:click={() => renamePage(p)}
+										class="rounded-md border border-yellow-500 bg-yellow-600 p-1 px-2 text-sm"
+										>Rename</button
+									>
+									<button
+										on:click={() => (confirmingDeleteId = p.id)}
+										class="rounded-md border border-red-500 bg-red-600 p-1 px-2 text-sm">Delete</button
+									>
+								{/if}
+							</div>
+						{/if}
+					</div>
+				{/each}
 			</div>
-		{/each}
 		{/if}
 	</ModalShell>
 {/if}

--- a/src/routes/app/project/[projectId]/[pageId]/+page.svelte
+++ b/src/routes/app/project/[projectId]/[pageId]/+page.svelte
@@ -244,7 +244,7 @@
 {#if !boardData && loading}
 	<Loader />
 {:else if boardData}
-	<PageHeader page={boardData.page} />
+	<PageHeader page={boardData.page} isHomePage={boardData.isHomePage} />
 
 	{#if !$EditingTiles && $LocalSettings.sentenceBuilder}<SentenceBuilder />{/if}
 
@@ -289,7 +289,11 @@
 		{/if}
 	</div>
 
-	<EditPagesModal projectId={boardData.project.id} pages={$ProjectPages} />
+	<EditPagesModal
+		projectId={boardData.project.id}
+		pages={$ProjectPages}
+		homePageId={boardData.project.homePageId}
+	/>
 	<CreatePageModal projectId={boardData.project.id} />
 	<EditPageModal />
 	<UnsavedChangesModal />

--- a/src/routes/app/project/[projectId]/[pageId]/_components/PageHeader.svelte
+++ b/src/routes/app/project/[projectId]/[pageId]/_components/PageHeader.svelte
@@ -2,9 +2,13 @@
 	import type { TilePage } from '$ts/common/types';
 	import { clickOutside } from '$ts/client/click-outside';
 	import { cn } from '$ts/client/cn';
-	import { AddingPage, EditingPages, EditingTiles, PageBeingEdited } from '$ts/client/stores';
+	import { AddingPage, EditingPages, EditingTiles, requestBoardRefresh } from '$ts/client/stores';
+	import { invalidateAll } from '$app/navigation';
+	import api from '$ts/client/api';
+	import { tick } from 'svelte';
 
 	export let page: TilePage;
+	export let isHomePage = false;
 
 	let element: HTMLElement;
 
@@ -20,10 +24,73 @@
 	}
 
 	let isDropDownOpen = false;
+
+	// Inline rename of the page name (only available in edit mode, never for the home page).
+	let renaming = false;
+	let draftName = '';
+	let renameInput: HTMLInputElement;
+	let savingName = false;
+
+	$: canRename = $EditingTiles && !isHomePage;
+
+	const startRename = async () => {
+		if (!canRename || renaming) return;
+		draftName = page.name;
+		renaming = true;
+		await tick();
+		renameInput?.focus();
+		renameInput?.select();
+	};
+
+	const cancelRename = () => {
+		renaming = false;
+	};
+
+	const commitRename = async () => {
+		if (!renaming) return;
+		renaming = false;
+
+		const name = draftName.trim();
+		if (!name || name === page.name) return;
+
+		savingName = true;
+		const response = await api.page.edit(page.id, { name });
+		savingName = false;
+
+		if (response.error) return alert(response.error);
+
+		await invalidateAll();
+		requestBoardRefresh();
+	};
 </script>
 
 <div class="relative h-14 bg-zinc-900 p-2 font-light text-zinc-100">
-	<p class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">{page.name}</p>
+	<div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+		{#if renaming}
+			<input
+				bind:this={renameInput}
+				bind:value={draftName}
+				on:blur={commitRename}
+				on:keydown={(e) => {
+					if (e.key === 'Enter') commitRename();
+					else if (e.key === 'Escape') cancelRename();
+				}}
+				class="rounded-md border border-zinc-600 bg-zinc-800 px-2 py-0.5 text-center text-zinc-100 outline-none focus:border-blue-500"
+			/>
+		{:else if canRename}
+			<button
+				on:click={startRename}
+				disabled={savingName}
+				title="Rename page"
+				class="flex items-center gap-2 rounded-md px-2 py-0.5 transition-all hover:bg-zinc-800"
+			>
+				<span>{page.name}</span>
+				<i class="bi bi-pencil text-xs text-zinc-400"></i>
+			</button>
+		{:else}
+			<p>{page.name}</p>
+		{/if}
+	</div>
 
 	{#if $EditingTiles}
 		<div class="absolute left-3 top-1/2 flex -translate-y-1/2 items-center gap-2">
@@ -55,16 +122,6 @@
 	<button
 		on:click={() => {
 			isDropDownOpen = false;
-			$PageBeingEdited = { ...page };
-		}}
-		class="flex items-center gap-2 rounded-md p-2 px-4 text-left transition-all hover:bg-zinc-700/[50%]"
-	>
-		<i class="bi bi-pencil text-sm"></i><span>Edit "{page.name}"</span>
-	</button>
-	<div class="h-[1px] w-full bg-zinc-700/[40%]"></div>
-	<button
-		on:click={() => {
-			isDropDownOpen = false;
 			$AddingPage = true;
 		}}
 		class="flex items-center gap-2 rounded-md p-2 px-4 text-left transition-all hover:bg-zinc-700/[50%]"
@@ -80,13 +137,4 @@
 	>
 		<i class="bi bi-grid text-sm"></i><span>View All Pages</span>
 	</button>
-	<div class="h-[1px] w-full bg-zinc-700/[40%]"></div>
-	<!-- <button
-		on:click={() => {
-			isDropDownOpen = false;
-		}}
-		class="flex items-center gap-2 rounded-md p-2 px-4 text-left transition-all hover:bg-zinc-700/[50%]"
-	>
-		<i class="bi bi-cloud-upload text-sm"></i><span>Upload "{page.name}" to Marketplace</span>
-	</button> -->
 </div>

--- a/src/ts/client/api/endpoints/project.ts
+++ b/src/ts/client/api/endpoints/project.ts
@@ -84,6 +84,7 @@ async function editProject(
 		columns?: number;
 		rows?: number;
 		imageUrl?: string;
+		homePageId?: string;
 	}
 ) {
 	const response = (await fetchFromAPI({


### PR DESCRIPTION
## Changes

**Rename**
- The page name in the header is now click-to-rename (Enter saves, Esc cancels), but **only in edit mode** so it can't be triggered accidentally during normal AAC use.
- Removed the "Edit \"Page Name\"" action from the Page Actions dropdown — it was a misnomer (it only renamed).

**Home page**
- The home page is now identified by `project.homePageId` instead of matching the name `"Home"`.
- The page list shows a **Home** badge on the current home page, and a **Set as Home** action on the others (new `homePageId` field on `project.edit`, backed by freespeech-api #9).
- Rename and delete are hidden/disabled for the home page; inline rename is disabled for it too.

**Delete**
- Deleting a page now has an inline **"Delete page? Yes / No"** confirm step instead of deleting immediately.

**Polish**
- Redesigned the "View All Pages" list as card rows.
- Removed the stray trailing hairline border after "View All Pages" in the dropdown.

## Depends on
- freespeech-api #9 (the `homePageId` update endpoint) for "Set as Home" to work.

## Verification
Built (Vite/adapter-node) and deployed to freespeechaac.com; service healthy (HTTP 200 on :5105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)